### PR TITLE
Fix tinytag.__str__ for Python 2.6

### DIFF
--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -72,7 +72,8 @@ class TinyTag(object):
         raise LookupError('No tag reader found to support filetype!')
 
     def __str__(self):
-        return str({k: v for k, v in self.__dict__.items() if not k.startswith('_')})
+        public_attrs = ((k, v) for k, v in self.__dict__.items() if not k.startswith('_'))
+        return str(dict(public_attrs))
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
Python 2.6 doesn't support dict comprehensions
