### PR TITLE
Add a MANIFEST.in to include text files into package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include *.md
+include *.rst
+include *.txt
+
+global-exclude *.pyc
+global-exclude .gitignore
+global-exclude .DS_Store


### PR DESCRIPTION
I hit this error when installing directly from pypi. Adding a MANIFEST.in is a simple way to fix this. 
http://docs.python.org/2/distutils/sourcedist.html#specifying-the-files-to-distribute

```
pip install tinytag==0.6.0
Downloading/unpacking tinytag==0.6.0
  Downloading tinytag-0.6.0.tar.gz
  Running setup.py (path:/home/rizumu/.virtualenvs/myenv/build/tinytag/setup.py) egg_info for package tinytag
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/home/rizumu/.virtualenvs/myenv/build/tinytag/setup.py", line 17, in <module>
        long_description=(open('README.md').read()),
    IOError: [Errno 2] No such file or directory: 'README.md'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/home/rizumu/.virtualenvs/myenv/build/tinytag/setup.py", line 17, in <module>

    long_description=(open('README.md').read()),

IOError: [Errno 2] No such file or directory: 'README.md'
```
