### PR TITLE
Delete twine from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ python_requires = >= 2.7
 setup_requires =
   setuptools >= 38.6
   pip >= 10
-  twine >= 1.11
 include_package_data = True
 packages = find:
 install_requires =


### PR DESCRIPTION
`twine` is not the requires while installing and using this lib. Put `twine`in `setup_requires` will download it when `pip` install `tinytag`. Ref https://setuptools.readthedocs.io/en/latest/setuptools.html