### PR TITLE
Include name in setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,7 @@ def get_version():
         return version_line.split("=")[1].strip().strip("\"'")
 
 
-setup(version=get_version())
+setup(
+        name="tinytag",
+        version=get_version()
+        )


### PR DESCRIPTION
Hey, I was getting an issue with tinytag installing as UNKNOWN (python 3.4.2, setuptools 5.5.1, pip 1.5.6), this fixed it.