### PR TITLE
Include name, find_packages() in setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from os.path import join
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def get_version():
@@ -9,4 +9,8 @@ def get_version():
         return version_line.split("=")[1].strip().strip("\"'")
 
 
-setup(version=get_version())
+setup(
+        name="tinytag",
+        version=get_version(),
+        packages=find_packages(),
+        )


### PR DESCRIPTION
Hey, I was getting an issue with tinytag installing as UNKNOWN (python 3.4.2, setuptools 5.5.1, pip 1.5.6), this fixed it.