### PR TITLE
Fix collections import deprecation warning

### DIFF
--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -281,9 +281,12 @@ def test_detect_magic_headers(testfile, expected):
         parser = TinyTag.get_parser_class(filename, fh)
     assert parser == expected
 
-@pytest.mark.xfail(raises=Exception)
 def test_show_hint_for_wrong_usage():
-    TinyTag('filename.mp3', 0)
+    with pytest.raises(Exception) as exc_info:
+        TinyTag('filename.mp3', 0)
+    assert exc_info.type == Exception
+    assert exc_info.value.args[0] == 'Use `TinyTag.get(filepath)` instead of `TinyTag(filepath)`'
+    
 
 def test_to_str():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/id3v22-test.mp3'))

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -78,7 +78,11 @@ def _bytes_to_int(b):
 
 class TinyTag(object):
     def __init__(self, filehandler, filesize, ignore_errors=False):
-        if isinstance(filehandler, str):
+        # This is required for compatibility between python2 and python3
+        # in python2 there is a difference between `str` and `unicode`
+        # whereas in python3 everything every string is `unicode` by default and
+        # the type `unicode` is deprecated
+        if type(filehandler).__name__ in ('str', 'unicode'):
             raise Exception('Use `TinyTag.get(filepath)` instead of `TinyTag(filepath)`')
         self._filehandler = filehandler
         self.filesize = filesize

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -35,7 +35,10 @@ from __future__ import print_function
 import json
 import operator
 from collections import OrderedDict, defaultdict
-from collections.abc import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 import codecs
 from functools import reduce
 import struct

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -34,7 +34,8 @@ from __future__ import print_function
 
 import json
 import operator
-from collections import MutableMapping, OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict
+from collections.abc import MutableMapping
 import codecs
 from functools import reduce
 import struct


### PR DESCRIPTION
Abstract baseclasses will no longer be importable from collections
directly but only from collections.abc starting with python 3.10.
Hence, the update of the imports.