### PR TITLE
Fix invalid duration for .wma files

### DIFF
--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -94,7 +94,7 @@ testfiles = OrderedDict([
     ('samples/flac_with_image.flac', {'extra': {}, 'filesize': 80000, 'album': 'smilin´ in circles', 'artist': 'Andreas Kümmert', 'bitrate': 7.479655337482049, 'channels': 2, 'disc': '1', 'disc_total': '1', 'duration': 83.56, 'genre': 'Blues', 'samplerate': 44100, 'title': 'intro', 'track': '01', 'track_total': '8'}),
 
     # WMA
-    ('samples/test2.wma', {'extra': {}, 'samplerate': 44100, 'album': 'The Colour and the Shape', 'title': 'Doll', 'bitrate': 64.04, 'filesize': 5800, 'track': '1', 'albumartist': 'Foo Fighters', 'artist': 'Foo Fighters', 'duration': 86.406, 'track_total': None, 'year': '1997', 'genre': 'Alternative', 'comment': '', 'composer': 'Foo Fighters'}),
+    ('samples/test2.wma', {'extra': {}, 'samplerate': 44100, 'album': 'The Colour and the Shape', 'title': 'Doll', 'bitrate': 64.04, 'filesize': 5800, 'track': '1', 'albumartist': 'Foo Fighters', 'artist': 'Foo Fighters', 'duration': 83.406, 'track_total': None, 'year': '1997', 'genre': 'Alternative', 'comment': '', 'composer': 'Foo Fighters'}),
 
     # M4A/MP4
     ('samples/test.m4a', {'extra': {}, 'samplerate': 44100, 'duration': 314.97,  'bitrate': 256.0, 'channels': 2, 'genre': 'Pop', 'year': '2011', 'title': 'Nothing', 'album': 'Only Our Hearts To Lose', 'track_total': '11', 'track': '11', 'artist': 'Marian', 'filesize': 61432}),

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -1195,7 +1195,9 @@ class Wma(TinyTag):
                     ('maximum_data_packet_size', 4, True),
                     ('maximum_bitrate', 4, False),
                 ])
-                self.duration = blocks.get('play_duration') / float(10000000)
+                # According to the specification, we need to subtract the preroll from play_duration
+                # to get the actual duration of the file
+                self.duration = max(blocks.get('play_duration') / float(10000000) - blocks.get('preroll') / float(1000), 0.0)
             elif object_id == Wma.ASF_STREAM_PROPERTIES_OBJECT:
                 blocks = self.read_blocks(fh, [
                     ('stream_type', 16, False),


### PR DESCRIPTION
From http://web.archive.org/web/20131203084402/http://msdn.microsoft.com/en-us/library/bb643323.aspx:

> Preroll
> 
> Specifies the amount of time to buffer data before starting to play the file, in millisecond units. If this value is nonzero, the Play Duration field and all of the payload Presentation Time fields have been offset by this amount. Therefore, player software must subtract the value in the preroll field from the play duration and presentation times to calculate their actual values.