### PR TITLE
Add flake8 linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        exclude:
+          - os: macos-latest
+            python: 'pypy-3.6'  # Not installable
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install dependencies
+        run: python -m pip install flake8 pytest pytest-cov
+
+      - name: Flake8 linter
+        run: python -m flake8
+
+      - name: Unit tests
+        run: python -m pytest --cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,16 +42,14 @@ install_requires =
 tests =
   pytest
   pytest-cov
-  coveralls
   flake8
 
 [options.entry_points]
 console_scripts =
 
 [flake8]
-max-line-length = 132
+max-line-length = 100
 exclude = .git,__pycache__,.eggs/,doc/,docs/,build/,dist/,archive/,src/
-ignore = E501
 
 [coverage:run]
 cover_pylib = false

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ def get_version():
         return version_line.split("=")[1].strip().strip("\"'")
 
 
-setup(
-        name="tinytag",
-        version=get_version(),
-        packages=find_packages(),
-        )
+setup(name="tinytag",
+      version=get_version(),
+      packages=find_packages())

--- a/tinytag/__init__.py
+++ b/tinytag/__init__.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from .tinytag import TinyTag, TinyTagException, ID3, Ogg, Wave, Flac
 import sys
+from .tinytag import TinyTag
 
 
 __version__ = '1.8.0'
+
 
 if __name__ == '__main__':
     print(TinyTag.get(sys.argv[1]))

--- a/tinytag/__main__.py
+++ b/tinytag/__main__.py
@@ -1,26 +1,29 @@
+from __future__ import absolute_import
+from os.path import splitext
 import os
 import json
 import sys
-from os.path import splitext
 
-from tinytag import TinyTag, TinyTagException
+from tinytag.tinytag import TinyTag, TinyTagException
+
 
 def usage():
     print('''tinytag [options] <filename...>
-    
+
     -h, --help
         Display help
-    
+
     -i, --save-image <image-path>
         Save the cover art to a file
-    
+
     -f, --format json|csv|tsv|tabularcsv
         Specify how the output should be formatted
-    
+
     -s, --skip-unsupported
-        Skip files that do not have a file extension supported by tinytag 
-    
-    ''')
+        Skip files that do not have a file extension supported by tinytag
+
+''')
+
 
 def pop_param(name, _default):
     if name in sys.argv:
@@ -29,12 +32,14 @@ def pop_param(name, _default):
         return sys.argv.pop(idx)
     return _default
 
+
 def pop_switch(name, _default):
     if name in sys.argv:
         idx = sys.argv.index(name)
         sys.argv.pop(idx)
         return True
     return False
+
 
 try:
     display_help = pop_switch('--help', False) or pop_switch('-h', False)

--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -12,17 +12,14 @@ from __future__ import unicode_literals
 
 import io
 import os
+import re
 import shutil
 import sys
-import tempfile
 
 import pytest
-import re
-
 from pytest import raises
 
-from tinytag import TinyTagException, TinyTag, ID3, Ogg, Wave, Flac
-from tinytag.tinytag import Wma, MP4, Aiff
+from tinytag.tinytag import TinyTag, TinyTagException, ID3, Ogg, Wave, Flac, Wma, MP4, Aiff
 
 try:
     from collections import OrderedDict
@@ -32,83 +29,307 @@ except ImportError:
 
 testfiles = OrderedDict([
     # MP3
-    ('samples/vbri.mp3', {'extra': {'url': ''}, 'channels': 2, 'samplerate': 44100, 'track_total': None, 'duration': 0.47020408163265304, 'album': 'I Can Walk On Water I Can Fly', 'year': '2007', 'title': 'I Can Walk On Water I Can Fly', 'artist': 'Basshunter', 'track': '01', 'filesize': 8192, 'audio_offset': 1007, 'genre': '(3)Dance', 'comment': 'Ripped by THSLIVE', 'composer': '', 'bitrate': 125.33333333333333}),
-    ('samples/cbr.mp3', {'extra': {}, 'channels': 2, 'samplerate': 44100, 'track_total': None, 'duration': 0.49, 'album': 'I Can Walk On Water I Can Fly', 'year': '2007', 'title': 'I Can Walk On Water I Can Fly', 'artist': 'Basshunter', 'track': '01', 'filesize': 8186, 'audio_offset': 246, 'bitrate': 128.0, 'genre': 'Dance', 'comment': 'Ripped by THSLIVE'}),
+    ('samples/vbri.mp3',
+        {'extra': {'url': ''}, 'channels': 2, 'samplerate': 44100, 'track_total': None,
+         'duration': 0.47020408163265304, 'album': 'I Can Walk On Water I Can Fly', 'year': '2007',
+         'title': 'I Can Walk On Water I Can Fly', 'artist': 'Basshunter', 'track': '01',
+         'filesize': 8192, 'audio_offset': 1007, 'genre': '(3)Dance',
+         'comment': 'Ripped by THSLIVE', 'composer': '', 'bitrate': 125.33333333333333}),
+    ('samples/cbr.mp3',
+        {'extra': {}, 'channels': 2, 'samplerate': 44100, 'track_total': None, 'duration': 0.49,
+         'album': 'I Can Walk On Water I Can Fly', 'year': '2007',
+         'title': 'I Can Walk On Water I Can Fly', 'artist': 'Basshunter', 'track': '01',
+         'filesize': 8186, 'audio_offset': 246, 'bitrate': 128.0, 'genre': 'Dance',
+         'comment': 'Ripped by THSLIVE'}),
     # the output of the lame encoder was 185.4 bitrate, but this is good enough for now
-    ('samples/vbr_xing_header.mp3', {'extra': {}, 'bitrate': 186.04383278145696, 'channels': 1, 'samplerate': 44100, 'duration': 3.944489795918367, 'filesize': 91731, 'audio_offset': 441}),
-    ('samples/vbr_xing_header_2channel.mp3', {'extra': {}, 'filesize': 2000, 'album': "The Harpers' Masque", 'artist': 'Knodel and Valencia', 'audio_offset': 694, 'bitrate': 46.276128290848305, 'channels': 2, 'duration': 250.04408163265308, 'samplerate': 22050, 'title': 'Lochaber No More', 'year': '1992'}),
-    ('samples/id3v22-test.mp3', {'extra': {}, 'channels': 2, 'samplerate': 44100, 'track_total': '11', 'duration': 0.138, 'album': 'Hymns for the Exiled', 'year': '2004', 'title': 'cosmic american', 'artist': 'Anais Mitchell', 'track': '3', 'filesize': 5120, 'audio_offset': 2225, 'bitrate': 160.0, 'comment': 'Waterbug Records, www.anaismitchell.com'}),
-    ('samples/silence-44-s-v1.mp3', {'extra': {}, 'channels': 2, 'samplerate': 44100, 'genre': 'Darkwave', 'track_total': None, 'duration': 3.7355102040816326, 'album': 'Quod Libet Test Data', 'year': '2004', 'title': 'Silence', 'artist': 'piman', 'track': '2', 'filesize': 15070, 'audio_offset': 0, 'bitrate': 32.0, 'comment': ''}),
-    ('samples/id3v1-latin1.mp3', {'extra': {}, 'channels': None, 'samplerate': 44100, 'genre': 'Rock', 'samplerate': None, 'album': 'The Young Americans', 'title': 'Play Dead', 'filesize': 256, 'track': '12', 'artist': 'Björk', 'track_total': None, 'year': '1993', 'comment': '                            '}),
-    ('samples/UTF16.mp3', {'extra': {'text': 'MusicBrainz Artist Id664c3e0e-42d8-48c1-b209-1efca19c0325', 'url': 'WIKIPEDIA_RELEASEhttp://en.wikipedia.org/wiki/High_Violet'}, 'channels': None, 'samplerate': None, 'track_total': '11', 'track': '07', 'artist': 'The National', 'year': '2010', 'album': 'High Violet', 'title': 'Lemonworld', 'filesize': 20480, 'genre': 'Indie', 'comment': 'Track 7'}),
-    ('samples/utf-8-id3v2.mp3', {'extra': {}, 'channels': None, 'samplerate': 44100, 'genre': 'Acustico', 'track_total': '21', 'track': '01', 'filesize': 2119, 'title': 'Gran día', 'artist': 'Paso a paso', 'album': 'S/T', 'year': None, 'samplerate': None, 'disc': '', 'disc_total': '0'}),
-    ('samples/empty_file.mp3', {'extra': {}, 'channels': None, 'samplerate': None, 'track_total': None, 'album': None, 'year': None, 'title': None, 'track': None, 'artist': None, 'filesize': 0}),
-    ('samples/silence-44khz-56k-mono-1s.mp3', {'extra': {}, 'channels': 1, 'samplerate': 44100, 'duration': 1.018, 'samplerate': 44100, 'filesize': 7280, 'audio_offset': 0, 'bitrate': 56.0}),
-    ('samples/silence-22khz-mono-1s.mp3', {'extra': {}, 'channels': 1, 'samplerate': 22050, 'filesize': 4284, 'audio_offset': 0, 'bitrate': 32.0, 'duration': 1.0438932496075353}),
-    ('samples/id3v24-long-title.mp3', {'extra': {}, 'track': '1', 'disc_total': '1', 'album': 'The Double EP: A Sea of Split Peas', 'filesize': 10000, 'channels': None, 'track_total': '12', 'genre': 'AlternRock', 'title': 'Out of the Woodwork', 'artist': 'Courtney Barnett', 'albumartist': 'Courtney Barnett', 'samplerate': None, 'year': None, 'disc': '1', 'comment': 'Amazon.com Song ID: 240853806', 'composer': 'Courtney Barnett'}),
-    ('samples/utf16be.mp3', {'extra': {}, 'title': '52-girls', 'filesize': 2048, 'track': '6', 'album': 'party mix', 'artist': 'The B52s', 'genre': 'Rock', 'albumartist': None, 'disc': None, 'channels': None}),
-    ('samples/id3v22_image.mp3', {'extra': {}, 'title': 'Kids (MGMT Cover) ', 'filesize': 35924, 'album': 'winniecooper.net ', 'artist': 'The Kooks', 'year': '2008', 'channels': None, 'genre': '.'}),
-    ('samples/id3v22.TCO.genre.mp3', {'extra': {}, 'filesize': 500, 'album': 'ARTPOP', 'artist': 'Lady GaGa', 'comment': 'engiTunPGAP0', 'genre': 'Pop', 'title': 'Applause'}),
-    ('samples/id3_comment_utf_16_with_bom.mp3', {'extra': {'isrc': 'USTC40852229'}, 'filesize': 19980, 'album': 'Ghosts I-IV', 'albumartist': 'Nine Inch Nails', 'artist': 'Nine Inch Nails', 'comment': '', 'disc': '1', 'disc_total': '2', 'title': '1 Ghosts I', 'track': '1', 'track_total': '36', 'year': '2008', 'comment': '3/4 time'}),
-    ('samples/id3_comment_utf_16_double_bom.mp3', {'extra': {'text': 'LABEL\ufeffUnclear'}, 'filesize': 512, 'album': 'The Embrace', 'artist': 'Johannes Heil & D.Diggler', 'comment': 'Unclear', 'title': 'The Embrace (Romano Alfieri Remix)', 'track': '04-johannes_heil_and_d.diggler-the_embrace_(romano_alfieri_remix)', 'year': '2012'}),
-    ('samples/id3_genre_id_out_of_bounds.mp3', {'extra': {}, 'filesize': 512, 'album': 'MECHANICAL ANIMALS', 'artist': 'Manson', 'comment': '', 'genre': '(255)', 'title': '01 GREAT BIG WHITE WORLD', 'track': 'Marilyn', 'year': '0'}),
-    ('samples/image-text-encoding.mp3', {'extra': {}, 'channels': 1, 'samplerate': 22050, 'filesize': 11104, 'title': 'image-encoding', 'audio_offset': 6820, 'bitrate': 32.0, 'duration': 1.0438932496075353}),
-    ('samples/id3v1_does_not_overwrite_id3v2.mp3', {'filesize': 1130, 'album': 'Somewhere Far Beyond', 'albumartist': 'Blind Guardian', 'artist': 'Blind Guardian', 'comment': '', 'extra': {'text': 'LOVE RATINGL'}, 'genre': 'Power Metal', 'title': 'Time What Is Time', 'track': '01', 'year': '1992'}),
-    ('samples/nicotinetestdata.mp3', {'filesize': 80919, 'audio_offset': 45, 'channels': 2, 'duration': 5.067755102040817, 'extra': {}, 'samplerate': 44100, 'bitrate': 127.6701030927835}),
-    ('samples/chinese_id3.mp3', {'filesize': 1000, 'album': '½ÇÂäÖ®¸è', 'albumartist': 'ËÕÔÆ', 'artist': 'ËÕÔÆ', 'audio_offset': 512, 'bitrate': 128.0, 'channels': 2, 'duration': 0.052244897959183675, 'extra': {}, 'genre': 'ÐÝÏÐÒôÀÖ', 'samplerate': 44100, 'title': '½ÇÂäÖ®¸è', 'track': '1'}),
-    ('samples/cut_off_titles.mp3', {'filesize': 1000, 'album': 'ERB', 'artist': 'Epic Rap Battles Of History', 'audio_offset': 194, 'bitrate': 192.0, 'channels': 2, 'duration': 0.052244897959183675, 'extra': {}, 'samplerate': 44100, 'title': 'Tony Hawk VS Wayne Gretzky'}),
-    ('samples/id3_xxx_lang.mp3', {'filesize': 6943, 'album': 'eMOTIVe', 'albumartist': 'A Perfect Circle', 'artist': 'A Perfect Circle', 'audio_offset': 3647, 'bitrate': 192.0, 'channels': 2, 'duration': 0.13198711063372717, 'extra': {'isrc': 'USVI20400513', 'lyrics': "Don't fret, precious", 'text': 'SCRIPT\ufeffLatn'}, 'genre': 'Rock', 'samplerate': 44100, 'title': 'Counting Bodies Like Sheep to the Rhythm of the War Drums', 'track': '10', 'comment': '                            ', 'composer': 'Billy Howerdel/Maynard James Keenan', 'disc': '1', 'disc_total': '1', 'track_total': '12', 'year': '2004'}),
+    ('samples/vbr_xing_header.mp3',
+        {'extra': {}, 'bitrate': 186.04383278145696, 'channels': 1, 'samplerate': 44100,
+         'duration': 3.944489795918367, 'filesize': 91731, 'audio_offset': 441}),
+    ('samples/vbr_xing_header_2channel.mp3',
+        {'extra': {}, 'filesize': 2000, 'album': "The Harpers' Masque",
+         'artist': 'Knodel and Valencia', 'audio_offset': 694, 'bitrate': 46.276128290848305,
+         'channels': 2, 'duration': 250.04408163265308, 'samplerate': 22050,
+         'title': 'Lochaber No More', 'year': '1992'}),
+    ('samples/id3v22-test.mp3',
+        {'extra': {}, 'channels': 2, 'samplerate': 44100, 'track_total': '11', 'duration': 0.138,
+         'album': 'Hymns for the Exiled', 'year': '2004', 'title': 'cosmic american',
+         'artist': 'Anais Mitchell', 'track': '3', 'filesize': 5120, 'audio_offset': 2225,
+         'bitrate': 160.0, 'comment': 'Waterbug Records, www.anaismitchell.com'}),
+    ('samples/silence-44-s-v1.mp3',
+        {'extra': {}, 'channels': 2, 'samplerate': 44100, 'genre': 'Darkwave', 'track_total': None,
+         'duration': 3.7355102040816326, 'album': 'Quod Libet Test Data', 'year': '2004',
+         'title': 'Silence', 'artist': 'piman', 'track': '2', 'filesize': 15070, 'audio_offset': 0,
+         'bitrate': 32.0, 'comment': ''}),
+    ('samples/id3v1-latin1.mp3',
+        {'extra': {}, 'channels': None, 'samplerate': None, 'genre': 'Rock',
+         'album': 'The Young Americans', 'title': 'Play Dead', 'filesize': 256, 'track': '12',
+         'artist': 'Björk', 'track_total': None, 'year': '1993',
+         'comment': '                            '}),
+    ('samples/UTF16.mp3',
+        {'extra': {'text': 'MusicBrainz Artist Id664c3e0e-42d8-48c1-b209-1efca19c0325',
+         'url': 'WIKIPEDIA_RELEASEhttp://en.wikipedia.org/wiki/High_Violet'}, 'channels': None,
+         'samplerate': None, 'track_total': '11', 'track': '07', 'artist': 'The National',
+         'year': '2010', 'album': 'High Violet', 'title': 'Lemonworld', 'filesize': 20480,
+         'genre': 'Indie', 'comment': 'Track 7'}),
+    ('samples/utf-8-id3v2.mp3',
+        {'extra': {}, 'channels': None, 'samplerate': None, 'genre': 'Acustico',
+         'track_total': '21', 'track': '01', 'filesize': 2119, 'title': 'Gran día',
+         'artist': 'Paso a paso', 'album': 'S/T', 'year': None, 'disc': '', 'disc_total': '0'}),
+    ('samples/empty_file.mp3',
+        {'extra': {}, 'channels': None, 'samplerate': None, 'track_total': None, 'album': None,
+         'year': None, 'title': None, 'track': None, 'artist': None, 'filesize': 0}),
+    ('samples/silence-44khz-56k-mono-1s.mp3',
+        {'extra': {}, 'channels': 1, 'samplerate': 44100, 'duration': 1.018, 'filesize': 7280,
+         'audio_offset': 0, 'bitrate': 56.0}),
+    ('samples/silence-22khz-mono-1s.mp3',
+        {'extra': {}, 'channels': 1, 'samplerate': 22050, 'filesize': 4284, 'audio_offset': 0,
+         'bitrate': 32.0, 'duration': 1.0438932496075353}),
+    ('samples/id3v24-long-title.mp3',
+        {'extra': {}, 'track': '1', 'disc_total': '1',
+         'album': 'The Double EP: A Sea of Split Peas', 'filesize': 10000,
+         'channels': None, 'track_total': '12', 'genre': 'AlternRock',
+         'title': 'Out of the Woodwork', 'artist': 'Courtney Barnett',
+         'albumartist': 'Courtney Barnett', 'samplerate': None, 'year': None, 'disc': '1',
+         'comment': 'Amazon.com Song ID: 240853806', 'composer': 'Courtney Barnett'}),
+    ('samples/utf16be.mp3',
+        {'extra': {}, 'title': '52-girls', 'filesize': 2048, 'track': '6', 'album': 'party mix',
+         'artist': 'The B52s', 'genre': 'Rock', 'albumartist': None, 'disc': None,
+         'channels': None}),
+    ('samples/id3v22_image.mp3',
+        {'extra': {}, 'title': 'Kids (MGMT Cover) ', 'filesize': 35924,
+         'album': 'winniecooper.net ', 'artist': 'The Kooks', 'year': '2008',
+         'channels': None, 'genre': '.'}),
+    ('samples/id3v22.TCO.genre.mp3',
+        {'extra': {}, 'filesize': 500, 'album': 'ARTPOP', 'artist': 'Lady GaGa',
+         'comment': 'engiTunPGAP0', 'genre': 'Pop', 'title': 'Applause'}),
+    ('samples/id3_comment_utf_16_with_bom.mp3',
+        {'extra': {'isrc': 'USTC40852229'}, 'filesize': 19980, 'album': 'Ghosts I-IV',
+         'albumartist': 'Nine Inch Nails', 'artist': 'Nine Inch Nails', 'disc': '1',
+         'disc_total': '2', 'title': '1 Ghosts I', 'track': '1', 'track_total': '36',
+         'year': '2008', 'comment': '3/4 time'}),
+    ('samples/id3_comment_utf_16_double_bom.mp3',
+        {'extra': {'text': 'LABEL\ufeffUnclear'}, 'filesize': 512, 'album': 'The Embrace',
+         'artist': 'Johannes Heil & D.Diggler', 'comment': 'Unclear',
+         'title': 'The Embrace (Romano Alfieri Remix)',
+         'track': '04-johannes_heil_and_d.diggler-the_embrace_(romano_alfieri_remix)',
+         'year': '2012'}),
+    ('samples/id3_genre_id_out_of_bounds.mp3',
+        {'extra': {}, 'filesize': 512, 'album': 'MECHANICAL ANIMALS', 'artist': 'Manson',
+         'comment': '', 'genre': '(255)', 'title': '01 GREAT BIG WHITE WORLD', 'track': 'Marilyn',
+         'year': '0'}),
+    ('samples/image-text-encoding.mp3',
+        {'extra': {}, 'channels': 1, 'samplerate': 22050, 'filesize': 11104,
+         'title': 'image-encoding', 'audio_offset': 6820, 'bitrate': 32.0,
+         'duration': 1.0438932496075353}),
+    ('samples/id3v1_does_not_overwrite_id3v2.mp3',
+        {'filesize': 1130, 'album': 'Somewhere Far Beyond', 'albumartist': 'Blind Guardian',
+         'artist': 'Blind Guardian', 'comment': '', 'extra': {'text': 'LOVE RATINGL'},
+         'genre': 'Power Metal', 'title': 'Time What Is Time', 'track': '01', 'year': '1992'}),
+    ('samples/nicotinetestdata.mp3',
+        {'extra': {}, 'filesize': 80919, 'audio_offset': 45, 'channels': 2,
+         'duration': 5.067755102040817, 'samplerate': 44100, 'bitrate': 127.6701030927835}),
+    ('samples/chinese_id3.mp3',
+        {'extra': {}, 'filesize': 1000, 'album': '½ÇÂäÖ®¸è', 'albumartist': 'ËÕÔÆ',
+         'artist': 'ËÕÔÆ', 'audio_offset': 512, 'bitrate': 128.0, 'channels': 2,
+         'duration': 0.052244897959183675, 'genre': 'ÐÝÏÐÒôÀÖ', 'samplerate': 44100,
+         'title': '½ÇÂäÖ®¸è', 'track': '1'}),
+    ('samples/cut_off_titles.mp3',
+        {'extra': {}, 'filesize': 1000, 'album': 'ERB', 'artist': 'Epic Rap Battles Of History',
+         'audio_offset': 194, 'bitrate': 192.0, 'channels': 2, 'duration': 0.052244897959183675,
+         'samplerate': 44100, 'title': 'Tony Hawk VS Wayne Gretzky'}),
+    ('samples/id3_xxx_lang.mp3',
+        {'extra': {'isrc': 'USVI20400513', 'lyrics': "Don't fret, precious",
+                   'text': 'SCRIPT\ufeffLatn'},
+         'filesize': 6943, 'album': 'eMOTIVe', 'albumartist': 'A Perfect Circle',
+         'artist': 'A Perfect Circle', 'audio_offset': 3647, 'bitrate': 192.0, 'channels': 2,
+         'duration': 0.13198711063372717, 'genre': 'Rock',
+         'samplerate': 44100, 'title': 'Counting Bodies Like Sheep to the Rhythm of the War Drums',
+         'track': '10', 'comment': '                            ',
+         'composer': 'Billy Howerdel/Maynard James Keenan', 'disc': '1', 'disc_total': '1',
+         'track_total': '12', 'year': '2004'}),
 
 
     # OGG
-    ('samples/empty.ogg', {'extra': {}, 'track_total': None, 'duration': 3.684716553287982, 'album': None, '_max_samplenum': 162496, 'year': None, 'title': None, 'artist': None, 'track': None, '_tags_parsed': False, 'filesize': 4328, 'audio_offset': 0, 'bitrate': 112.0, 'samplerate': 44100}),
-    ('samples/multipagecomment.ogg', {'extra': {}, 'track_total': None, 'duration': 3.684716553287982, 'album': None, '_max_samplenum': 162496, 'year': None, 'title': None, 'artist': None, 'track': None, '_tags_parsed': False, 'filesize': 135694, 'audio_offset': 0, 'bitrate': 112, 'samplerate': 44100}),
-    ('samples/multipage-setup.ogg', {'extra': {}, 'genre': 'JRock', 'track_total': None, 'duration': 4.128798185941043, 'album': 'Timeless', 'year': '2006', 'title': 'Burst', 'artist': 'UVERworld', 'track': '7', '_tags_parsed': False, 'filesize': 76983, 'audio_offset': 0, 'bitrate': 160.0, 'samplerate': 44100}),
-    ('samples/test.ogg', {'extra': {}, 'track_total': None, 'duration': 1.0, 'album': 'the boss', 'year': '2006', 'title': 'the boss', 'artist': 'james brown', 'track': '1', '_tags_parsed': False, 'filesize': 7467, 'audio_offset': 0, 'bitrate': 160.0, 'samplerate': 44100, 'comment': 'hello!'}),
-    ('samples/corrupt_metadata.ogg', {'extra': {}, 'filesize': 18648, 'audio_offset': 0, 'bitrate': 80.0, 'duration': 2.132358276643991, 'samplerate': 44100}),
-    ('samples/composer.ogg', {'extra': {}, 'filesize': 4480, 'album': 'An Album', 'artist': 'An Artist', 'audio_offset': 0, 'bitrate': 112.0, 'duration': 3.684716553287982, 'genre': 'Some Genre', 'samplerate': 44100, 'title': 'A Title', 'track': '2', 'year': '2007', 'composer': 'some composer'}),
+    ('samples/empty.ogg',
+        {'extra': {}, 'track_total': None, 'duration': 3.684716553287982, 'album': None,
+         '_max_samplenum': 162496, 'year': None, 'title': None, 'artist': None, 'track': None,
+         '_tags_parsed': False, 'filesize': 4328, 'audio_offset': 0, 'bitrate': 112.0,
+         'samplerate': 44100}),
+    ('samples/multipagecomment.ogg',
+        {'extra': {}, 'track_total': None, 'duration': 3.684716553287982, 'album': None,
+         '_max_samplenum': 162496, 'year': None, 'title': None, 'artist': None, 'track': None,
+         '_tags_parsed': False, 'filesize': 135694, 'audio_offset': 0, 'bitrate': 112,
+         'samplerate': 44100}),
+    ('samples/multipage-setup.ogg',
+        {'extra': {}, 'genre': 'JRock', 'track_total': None, 'duration': 4.128798185941043,
+         'album': 'Timeless', 'year': '2006', 'title': 'Burst', 'artist': 'UVERworld', 'track': '7',
+         '_tags_parsed': False, 'filesize': 76983, 'audio_offset': 0, 'bitrate': 160.0,
+         'samplerate': 44100}),
+    ('samples/test.ogg',
+        {'extra': {}, 'track_total': None, 'duration': 1.0, 'album': 'the boss', 'year': '2006',
+         'title': 'the boss', 'artist': 'james brown', 'track': '1', '_tags_parsed': False,
+         'filesize': 7467, 'audio_offset': 0, 'bitrate': 160.0, 'samplerate': 44100,
+         'comment': 'hello!'}),
+    ('samples/corrupt_metadata.ogg',
+        {'extra': {}, 'filesize': 18648, 'audio_offset': 0, 'bitrate': 80.0,
+         'duration': 2.132358276643991, 'samplerate': 44100}),
+    ('samples/composer.ogg',
+        {'extra': {}, 'filesize': 4480, 'album': 'An Album', 'artist': 'An Artist',
+         'audio_offset': 0, 'bitrate': 112.0, 'duration': 3.684716553287982,
+         'genre': 'Some Genre', 'samplerate': 44100, 'title': 'A Title', 'track': '2',
+         'year': '2007', 'composer': 'some composer'}),
 
     # OPUS
-    ('samples/test.opus', {'extra': {}, 'albumartist': 'Alstroemeria Records', 'samplerate': 48000, 'channels': 2, 'track': '1', 'disc': '1', 'title': 'Bad Apple!!', 'duration': 2.0, 'year': '2008.05.25', 'filesize': 10000, 'artist': 'nomico', 'album': 'Exserens - A selection of Alstroemeria Records', 'comment': 'ARCD0018 - Lovelight'}),
-    ('samples/8khz_5s.opus', {'extra': {}, 'filesize': 7251, 'channels': 1, 'samplerate': 48000, 'duration': 5.0}),
+    ('samples/test.opus',
+        {'extra': {}, 'albumartist': 'Alstroemeria Records', 'samplerate': 48000, 'channels': 2,
+         'track': '1', 'disc': '1', 'title': 'Bad Apple!!', 'duration': 2.0, 'year': '2008.05.25',
+         'filesize': 10000, 'artist': 'nomico',
+         'album': 'Exserens - A selection of Alstroemeria Records',
+         'comment': 'ARCD0018 - Lovelight'}),
+    ('samples/8khz_5s.opus',
+        {'extra': {}, 'filesize': 7251, 'channels': 1, 'samplerate': 48000, 'duration': 5.0}),
 
     # WAV
-    ('samples/test.wav', {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176444, 'bitrate': 1411.2, 'samplerate': 44100, 'audio_offset': 36}),
-    ('samples/test3sMono.wav', {'extra': {}, 'channels': 1, 'duration': 3.0, 'filesize': 264644, 'bitrate': 705.6, 'duration': 3.0, 'samplerate': 44100, 'audio_offset': 36}),
-    ('samples/test-tagged.wav', {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176688, 'album': 'thealbum', 'artist': 'theartisst', 'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100, 'title': 'thetitle', 'track': '66', 'audio_offset': 36, 'comment': 'hello', 'year': '2014'}),
-    ('samples/test-riff-tags.wav', {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176540, 'album': None, 'artist': 'theartisst', 'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100, 'title': 'thetitle', 'track': None, 'audio_offset': 36, 'comment': 'hello', 'year': '2014'}),
-    ('samples/silence-22khz-mono-1s.wav', {'extra': {}, 'channels': 1, 'duration': 1.0, 'filesize': 48160, 'bitrate': 352.8, 'samplerate': 22050, 'audio_offset': 4088}),
-    ('samples/id3_header_with_a_zero_byte.wav', {'extra': {}, 'channels': 1, 'duration': 1.0, 'filesize': 44280, 'bitrate': 352.8, 'samplerate': 22050, 'audio_offset': 122, 'artist': 'Purpley', 'title': 'Test000', 'track': '17'}),
-    ('samples/adpcm.wav', {'extra': {}, 'channels': 1, 'duration': 12.167256235827665, 'filesize': 268686, 'bitrate': 176.4, 'samplerate': 44100, 'audio_offset': 82, 'artist': 'test artist', 'title': 'test title', 'track': '1', 'album': 'test album', 'comment': 'test comment', 'genre': 'test genre', 'year': '1990'}),
+    ('samples/test.wav',
+        {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176444, 'bitrate': 1411.2,
+         'samplerate': 44100, 'audio_offset': 36}),
+    ('samples/test3sMono.wav',
+        {'extra': {}, 'channels': 1, 'duration': 3.0, 'filesize': 264644, 'bitrate': 705.6,
+         'samplerate': 44100, 'audio_offset': 36}),
+    ('samples/test-tagged.wav',
+        {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176688, 'album': 'thealbum',
+         'artist': 'theartisst', 'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100,
+         'title': 'thetitle', 'track': '66', 'audio_offset': 36, 'comment': 'hello',
+         'year': '2014'}),
+    ('samples/test-riff-tags.wav',
+        {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 176540, 'album': None,
+         'artist': 'theartisst', 'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100,
+         'title': 'thetitle', 'track': None, 'audio_offset': 36, 'comment': 'hello',
+         'year': '2014'}),
+    ('samples/silence-22khz-mono-1s.wav',
+        {'extra': {}, 'channels': 1, 'duration': 1.0, 'filesize': 48160, 'bitrate': 352.8,
+         'samplerate': 22050, 'audio_offset': 4088}),
+    ('samples/id3_header_with_a_zero_byte.wav',
+        {'extra': {}, 'channels': 1, 'duration': 1.0, 'filesize': 44280, 'bitrate': 352.8,
+         'samplerate': 22050, 'audio_offset': 122, 'artist': 'Purpley', 'title': 'Test000',
+         'track': '17'}),
+    ('samples/adpcm.wav',
+        {'extra': {}, 'channels': 1, 'duration': 12.167256235827665, 'filesize': 268686,
+         'bitrate': 176.4, 'samplerate': 44100, 'audio_offset': 82, 'artist': 'test artist',
+         'title': 'test title', 'track': '1', 'album': 'test album', 'comment': 'test comment',
+         'genre': 'test genre', 'year': '1990'}),
 
     # FLAC
-    ('samples/flac1sMono.flac', {'extra': {}, 'genre': 'Avantgarde', 'track_total': None, 'album': 'alb', 'year': '2014', 'duration': 1.0, 'title': 'track', 'track': '23', 'artist': 'art', 'channels': 1, 'filesize': 26632, 'bitrate': 213.056, 'samplerate': 44100}),
-    ('samples/flac453sStereo.flac', {'extra': {}, 'channels': 2, 'track_total': None, 'album': None, 'year': None, 'duration': 453.51473922902494, 'title': None, 'track': None, 'artist': None, 'filesize': 84236, 'bitrate': 1.4859230399999999, 'samplerate': 44100}),
-    ('samples/flac1.5sStereo.flac', {'extra': {}, 'channels': 2, 'track_total': None, 'album': 'alb', 'year': '2014', 'duration': 1.4995238095238095, 'title': 'track', 'track': '23', 'artist': 'art', 'filesize': 59868, 'bitrate': 319.39739599872973, 'genre': 'Avantgarde', 'samplerate': 44100}),
-    ('samples/flac_application.flac', {'extra': {}, 'channels': 2, 'track_total': '11', 'album': 'Belle and Sebastian Write About Love', 'year': '2010-10-11', 'duration': 273.64, 'title': 'I Want the World to Stop', 'track': '4', 'artist': 'Belle and Sebastian', 'filesize': 13000, 'bitrate': 0.38006139453296306, 'samplerate': 44100}),
-    ('samples/no-tags.flac', {'extra': {}, 'channels': 2, 'track_total': None, 'album': None, 'year': None, 'duration': 3.684716553287982, 'title': None, 'track': None, 'artist': None, 'filesize': 4692, 'bitrate': 10.186943678613627, 'samplerate': 44100}),
-    ('samples/variable-block.flac', {'extra': {}, 'channels': 2, 'album': 'Appleseed Original Soundtrack', 'year': '2004', 'duration': 261.68, 'title': 'DIVE FOR YOU', 'track': '01', 'track_total': '11', 'artist': 'Boom Boom Satellites', 'filesize': 10240, 'bitrate': 0.31305411189238763, 'disc': '1', 'genre': 'Anime Soundtrack', 'samplerate': 44100, 'composer': 'Boom Boom Satellites (Lyrics)', 'disc_total': '2'}),
-    ('samples/106-invalid-streaminfo.flac', {'extra': {}, 'filesize': 4692}),
-    ('samples/106-short-picture-block-size.flac', {'extra': {}, 'filesize': 4692, 'bitrate': 10.186943678613627, 'channels': 2, 'duration': 3.68, 'samplerate': 44100}),
-    ('samples/with_id3_header.flac', {'extra': {}, 'filesize': 64837, 'album': '   ', 'artist': '群星', 'disc': '0', 'title': 'A 梦 哆啦 机器猫 短信铃声', 'track': '0', 'bitrate': 1143.72468, 'channels': 1, 'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100, 'year': '2018'}),
-    ('samples/with_padded_id3_header.flac', {'extra': {}, 'filesize': 16070, 'album': 'album', 'albumartist': None, 'artist': 'artist', 'audio_offset': None, 'bitrate': 283.4748, 'channels': 1, 'comment': None, 'disc': None, 'disc_total': None, 'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100, 'title': 'title', 'track': '1', 'track_total': None, 'year': '2018'}),
-    ('samples/with_padded_id3_header2.flac', {'extra': {}, 'filesize': 19522, 'album': 'Unbekannter Titel', 'albumartist': None, 'artist': 'Unbekannter Künstler', 'audio_offset': None, 'bitrate': 344.36807999999996, 'channels': 1, 'comment': None, 'disc': '1', 'disc_total': '1', 'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100, 'title': 'Track01', 'track': '01', 'track_total': '05', 'year': '2018'}),
-    ('samples/flac_with_image.flac', {'extra': {}, 'filesize': 80000, 'album': 'smilin´ in circles', 'artist': 'Andreas Kümmert', 'bitrate': 7.6591670655816175, 'channels': 2, 'disc': '1', 'disc_total': '1', 'duration': 83.56, 'genre': 'Blues', 'samplerate': 44100, 'title': 'intro', 'track': '01', 'track_total': '8'}),
+    ('samples/flac1sMono.flac',
+        {'extra': {}, 'genre': 'Avantgarde', 'track_total': None, 'album': 'alb', 'year': '2014',
+         'duration': 1.0, 'title': 'track', 'track': '23', 'artist': 'art', 'channels': 1,
+         'filesize': 26632, 'bitrate': 213.056, 'samplerate': 44100}),
+    ('samples/flac453sStereo.flac',
+        {'extra': {}, 'channels': 2, 'track_total': None, 'album': None, 'year': None,
+         'duration': 453.51473922902494, 'title': None, 'track': None, 'artist': None,
+         'filesize': 84236, 'bitrate': 1.4859230399999999, 'samplerate': 44100}),
+    ('samples/flac1.5sStereo.flac',
+        {'extra': {}, 'channels': 2, 'track_total': None, 'album': 'alb', 'year': '2014',
+         'duration': 1.4995238095238095, 'title': 'track', 'track': '23', 'artist': 'art',
+         'filesize': 59868, 'bitrate': 319.39739599872973, 'genre': 'Avantgarde',
+         'samplerate': 44100}),
+    ('samples/flac_application.flac',
+        {'extra': {}, 'channels': 2, 'track_total': '11',
+         'album': 'Belle and Sebastian Write About Love', 'year': '2010-10-11', 'duration': 273.64,
+         'title': 'I Want the World to Stop', 'track': '4', 'artist': 'Belle and Sebastian',
+         'filesize': 13000, 'bitrate': 0.38006139453296306, 'samplerate': 44100}),
+    ('samples/no-tags.flac',
+        {'extra': {}, 'channels': 2, 'track_total': None, 'album': None, 'year': None,
+         'duration': 3.684716553287982, 'title': None, 'track': None, 'artist': None,
+         'filesize': 4692, 'bitrate': 10.186943678613627, 'samplerate': 44100}),
+    ('samples/variable-block.flac',
+        {'extra': {}, 'channels': 2, 'album': 'Appleseed Original Soundtrack', 'year': '2004',
+         'duration': 261.68, 'title': 'DIVE FOR YOU', 'track': '01', 'track_total': '11',
+         'artist': 'Boom Boom Satellites', 'filesize': 10240, 'bitrate': 0.31305411189238763,
+         'disc': '1', 'genre': 'Anime Soundtrack', 'samplerate': 44100,
+         'composer': 'Boom Boom Satellites (Lyrics)', 'disc_total': '2'}),
+    ('samples/106-invalid-streaminfo.flac',
+        {'extra': {}, 'filesize': 4692}),
+    ('samples/106-short-picture-block-size.flac',
+        {'extra': {}, 'filesize': 4692, 'bitrate': 10.186943678613627, 'channels': 2,
+         'duration': 3.68, 'samplerate': 44100}),
+    ('samples/with_id3_header.flac',
+        {'extra': {}, 'filesize': 64837, 'album': '   ', 'artist': '群星', 'disc': '0',
+         'title': 'A 梦 哆啦 机器猫 短信铃声', 'track': '0', 'bitrate': 1143.72468, 'channels': 1,
+         'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100, 'year': '2018'}),
+    ('samples/with_padded_id3_header.flac',
+        {'extra': {}, 'filesize': 16070, 'album': 'album', 'albumartist': None, 'artist': 'artist',
+         'audio_offset': None, 'bitrate': 283.4748, 'channels': 1, 'comment': None, 'disc': None,
+         'disc_total': None, 'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100,
+         'title': 'title', 'track': '1', 'track_total': None, 'year': '2018'}),
+    ('samples/with_padded_id3_header2.flac',
+        {'extra': {}, 'filesize': 19522, 'album': 'Unbekannter Titel', 'albumartist': None,
+         'artist': 'Unbekannter Künstler', 'audio_offset': None, 'bitrate': 344.36807999999996,
+         'channels': 1, 'comment': None, 'disc': '1', 'disc_total': '1',
+         'duration': 0.45351473922902497, 'genre': 'genre', 'samplerate': 44100, 'title': 'Track01',
+         'track': '01', 'track_total': '05', 'year': '2018'}),
+    ('samples/flac_with_image.flac',
+        {'extra': {}, 'filesize': 80000, 'album': 'smilin´ in circles', 'artist': 'Andreas Kümmert',
+         'bitrate': 7.6591670655816175, 'channels': 2, 'disc': '1', 'disc_total': '1',
+         'duration': 83.56, 'genre': 'Blues', 'samplerate': 44100, 'title': 'intro', 'track': '01',
+         'track_total': '8'}),
 
     # WMA
-    ('samples/test2.wma', {'extra': {}, 'samplerate': 44100, 'album': 'The Colour and the Shape', 'title': 'Doll', 'bitrate': 64.04, 'filesize': 5800, 'track': '1', 'albumartist': 'Foo Fighters', 'artist': 'Foo Fighters', 'duration': 83.406, 'track_total': None, 'year': '1997', 'genre': 'Alternative', 'comment': '', 'composer': 'Foo Fighters'}),
+    ('samples/test2.wma',
+        {'extra': {}, 'samplerate': 44100, 'album': 'The Colour and the Shape', 'title': 'Doll',
+         'bitrate': 64.04, 'filesize': 5800, 'track': '1', 'albumartist': 'Foo Fighters',
+         'artist': 'Foo Fighters', 'duration': 83.406, 'track_total': None, 'year': '1997',
+         'genre': 'Alternative', 'comment': '', 'composer': 'Foo Fighters'}),
 
     # ALAC/M4A/MP4
-    ('samples/test.m4a', {'extra': {}, 'samplerate': 44100, 'duration': 314.97,  'bitrate': 256.0, 'channels': 2, 'genre': 'Pop', 'year': '2011', 'title': 'Nothing', 'album': 'Only Our Hearts To Lose', 'track_total': '11', 'track': '11', 'artist': 'Marian', 'filesize': 61432}),
-    ('samples/test2.m4a', {'extra': {}, 'bitrate': 256.0, 'track': '1', 'albumartist': "Millie Jackson - Get It Out 'cha System - 1978", 'duration': 167.78739229024944, 'filesize': 223365, 'channels': 2, 'year': '1978', 'artist': 'Millie Jackson', 'track_total': '9', 'disc_total': '1', 'genre': 'R&B/Soul', 'album': "Get It Out 'cha System", 'samplerate': 44100, 'disc': '1', 'title': 'Go Out and Get Some', 'comment': "Millie Jackson - Get It Out 'cha System - 1978", 'composer': "Millie Jackson - Get It Out 'cha System - 1978"}),
-    ('samples/iso8859_with_image.m4a', {'extra': {}, 'artist': 'Major Lazer', 'filesize': 57017, 'title': 'Cold Water (feat. Justin Bieber & M�)', 'album': 'Cold Water (feat. Justin Bieber & M�) - Single', 'year': '2016', 'samplerate': 44100, 'duration': 188.545, 'genre': 'Electronic;Music', 'albumartist': 'Major Lazer', 'channels': 2, 'bitrate': 125.584, 'comment': '? 2016 Mad Decent'}),
-    ('samples/alac_file.m4a', {'extra': {}, 'artist': 'Howard Shelley', 'composer': 'Clementi, Muzio (1752-1832)', 'filesize': 20000, 'title': 'Clementi: Piano Sonata in D major, Op 25 No 6 - Movement 2: Un poco andante', 'album': 'Clementi: The Complete Piano Sonatas, Vol. 4', 'year': '2009', 'track': '14', 'track_total': '27', 'disc': '1', 'disc_total': '1', 'samplerate': 44100, 'duration': 166.62639455782312, 'genre': 'Classical', 'albumartist': 'Howard Shelley', 'channels': 2, 'bitrate': 436.743}),
+    ('samples/test.m4a',
+        {'extra': {}, 'samplerate': 44100, 'duration': 314.97, 'bitrate': 256.0, 'channels': 2,
+         'genre': 'Pop', 'year': '2011', 'title': 'Nothing', 'album': 'Only Our Hearts To Lose',
+         'track_total': '11', 'track': '11', 'artist': 'Marian', 'filesize': 61432}),
+    ('samples/test2.m4a',
+        {'extra': {}, 'bitrate': 256.0, 'track': '1',
+         'albumartist': "Millie Jackson - Get It Out 'cha System - 1978",
+         'duration': 167.78739229024944, 'filesize': 223365, 'channels': 2, 'year': '1978',
+         'artist': 'Millie Jackson', 'track_total': '9', 'disc_total': '1', 'genre': 'R&B/Soul',
+         'album': "Get It Out 'cha System", 'samplerate': 44100, 'disc': '1',
+         'title': 'Go Out and Get Some',
+         'comment': "Millie Jackson - Get It Out 'cha System - 1978",
+         'composer': "Millie Jackson - Get It Out 'cha System - 1978"}),
+    ('samples/iso8859_with_image.m4a',
+        {'extra': {}, 'artist': 'Major Lazer', 'filesize': 57017,
+         'title': 'Cold Water (feat. Justin Bieber & M�)',
+         'album': 'Cold Water (feat. Justin Bieber & M�) - Single', 'year': '2016',
+         'samplerate': 44100, 'duration': 188.545, 'genre': 'Electronic;Music',
+         'albumartist': 'Major Lazer', 'channels': 2, 'bitrate': 125.584,
+         'comment': '? 2016 Mad Decent'}),
+    ('samples/alac_file.m4a',
+        {'extra': {}, 'artist': 'Howard Shelley', 'composer': 'Clementi, Muzio (1752-1832)',
+         'filesize': 20000,
+         'title': 'Clementi: Piano Sonata in D major, Op 25 No 6 - Movement 2: Un poco andante',
+         'album': 'Clementi: The Complete Piano Sonatas, Vol. 4', 'year': '2009', 'track': '14',
+         'track_total': '27', 'disc': '1', 'disc_total': '1', 'samplerate': 44100,
+         'duration': 166.62639455782312, 'genre': 'Classical', 'albumartist': 'Howard Shelley',
+         'channels': 2, 'bitrate': 436.743}),
 
     # AIFF
-    ('samples/test-tagged.aiff', {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 177620, 'artist': 'theartist', 'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100, 'track': '1', 'title': 'thetitle', 'album': 'thealbum', 'audio_offset': 76, 'comment': 'hello', 'year': '2014', }),
-    ('samples/test.aiff', {'extra': {'copyright': '℗ 1992 Ace Records'}, 'channels': 2, 'duration': 0.0, 'filesize': 164, 'artist': None, 'bitrate': 1411.2, 'genre': None, 'samplerate': 44100, 'track': None, 'title': 'Go Out and Get Some', 'album': None, 'audio_offset': 156, 'comment': 'Millie Jackson - Get It Out \'cha System - 1978', }),
-    ('samples/pluck-pcm8.aiff', {'extra': {}, 'channels': 2, 'duration': 0.2999546485260771, 'filesize': 6892, 'artist': 'Serhiy Storchaka', 'title': 'Pluck', 'album': 'Python Test Suite', 'bitrate': 176.4, 'samplerate': 11025, 'audio_offset': 116, 'comment': 'Audacity Pluck + Wahwah', }),
-    ('samples/M1F1-mulawC-AFsp.afc', {'extra': {}, 'channels': 2, 'duration':  2.936625, 'filesize': 47148, 'artist': None, 'title': None, 'album': None, 'bitrate': 256.0, 'samplerate': 8000, 'audio_offset': 154, 'comment': 'AFspdate: 2003-01-30 03:28:34 UTCuser: kabal@CAPELLAprogram: CopyAudio', }),
+    ('samples/test-tagged.aiff',
+        {'extra': {}, 'channels': 2, 'duration': 1.0, 'filesize': 177620, 'artist': 'theartist',
+         'bitrate': 1411.2, 'genre': 'Acid', 'samplerate': 44100, 'track': '1', 'title': 'thetitle',
+         'album': 'thealbum', 'audio_offset': 76, 'comment': 'hello', 'year': '2014'}),
+    ('samples/test.aiff',
+        {'extra': {'copyright': '℗ 1992 Ace Records'}, 'channels': 2, 'duration': 0.0,
+         'filesize': 164, 'artist': None, 'bitrate': 1411.2, 'genre': None, 'samplerate': 44100,
+         'track': None, 'title': 'Go Out and Get Some', 'album': None, 'audio_offset': 156,
+         'comment': 'Millie Jackson - Get It Out \'cha System - 1978'}),
+    ('samples/pluck-pcm8.aiff',
+        {'extra': {}, 'channels': 2, 'duration': 0.2999546485260771, 'filesize': 6892,
+         'artist': 'Serhiy Storchaka', 'title': 'Pluck', 'album': 'Python Test Suite',
+         'bitrate': 176.4, 'samplerate': 11025, 'audio_offset': 116,
+         'comment': 'Audacity Pluck + Wahwah'}),
+    ('samples/M1F1-mulawC-AFsp.afc',
+        {'extra': {}, 'channels': 2, 'duration': 2.936625, 'filesize': 47148, 'artist': None,
+         'title': None, 'album': None, 'bitrate': 256.0, 'samplerate': 8000, 'audio_offset': 154,
+         'comment': 'AFspdate: 2003-01-30 03:28:34 UTCuser: kabal@CAPELLAprogram: CopyAudio'}),
 
 ])
 
@@ -141,6 +362,7 @@ for filename in os.listdir(custom_samples_folder):
     else:
         # if there are no expected values, just try parsing the file
         testfiles[os.path.join('custom_samples', filename)] = {}
+
 
 @pytest.mark.parametrize("testfile,expected", [
     pytest.param(testfile, expected) for testfile, expected in testfiles.items()
@@ -184,7 +406,8 @@ def test_pathlib_compatibility():
         return
     testfile = next(iter(testfiles.keys()))
     filename = pathlib.Path(testfolder) / testfile
-    tag = TinyTag.get(filename)
+    TinyTag.get(filename)
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason='Windows does not support binary paths')
 def test_binary_path_compatibility():
@@ -202,120 +425,161 @@ def test_unsupported_extension():
     bogus_file = os.path.join(testfolder, 'samples/there_is_no_such_ext.bogus')
     TinyTag.get(bogus_file)
 
+
 def test_override_encoding():
     chinese_id3 = os.path.join(testfolder, 'samples/chinese_id3.mp3')
     tag = TinyTag.get(chinese_id3, encoding='gbk')
     assert tag.artist == '苏云'
     assert tag.album == '角落之歌'
 
+
 @pytest.mark.xfail(raises=NotImplementedError)
 def test_unsubclassed_tinytag_duration():
     tag = TinyTag(None, 0)
     tag._determine_duration(None)
+
 
 @pytest.mark.xfail(raises=NotImplementedError)
 def test_unsubclassed_tinytag_parse_tag():
     tag = TinyTag(None, 0)
     tag._parse_tag(None)
 
+
 def test_mp3_length_estimation():
     ID3.set_estimation_precision(0.7)
     tag = TinyTag.get(os.path.join(testfolder, 'samples/silence-44-s-v1.mp3'))
     assert 3.5 < tag.duration < 4.0
 
+
 @pytest.mark.xfail(raises=TinyTagException)
 def test_unexpected_eof():
-    tag = ID3.get(os.path.join(testfolder, 'samples/incomplete.mp3'))
+    ID3.get(os.path.join(testfolder, 'samples/incomplete.mp3'))
+
 
 @pytest.mark.xfail(raises=TinyTagException)
 def test_invalid_flac_file():
-    tag = Flac.get(os.path.join(testfolder, 'samples/silence-44-s-v1.mp3'))
+    Flac.get(os.path.join(testfolder, 'samples/silence-44-s-v1.mp3'))
+
 
 @pytest.mark.xfail(raises=TinyTagException)
 def test_invalid_mp3_file():
-    tag = ID3.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+    ID3.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+
 
 @pytest.mark.xfail(raises=TinyTagException)
 def test_invalid_ogg_file():
-    tag = Ogg.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+    Ogg.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+
 
 @pytest.mark.xfail(raises=TinyTagException)
 def test_invalid_wave_file():
-    tag = Wave.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+    Wave.get(os.path.join(testfolder, 'samples/flac1.5sStereo.flac'))
+
 
 @pytest.mark.xfail(raises=TinyTagException)
 def test_invalid_aiff_file():
-    tag = Aiff.get(os.path.join(testfolder, 'samples/ilbm.aiff'))
+    Aiff.get(os.path.join(testfolder, 'samples/ilbm.aiff'))
+
 
 def test_unpad():
     # make sure that unpad only removes trailing 0-bytes
     assert TinyTag._unpad('foo\x00') == 'foo'
     assert TinyTag._unpad('foo\x00bar\x00') == 'foobar'
 
+
 def test_mp3_image_loading():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/cover_img.mp3'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 140000 < len(image_data) < 150000, 'Image is %d bytes but should be around 145kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 140000 < len(image_data) < 150000, ('Image is %d bytes but should be around 145kb' %
+                                               len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_mp3_id3v22_image_loading():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/id3v22_image.mp3'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 18000 < len(image_data) < 19000, 'Image is %d bytes but should be around 18.1kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 18000 < len(image_data) < 19000, ('Image is %d bytes but should be around 18.1kb' %
+                                             len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_mp3_image_loading_without_description():
-    tag = TinyTag.get(os.path.join(testfolder, 'samples/id3image_without_description.mp3'), image=True)
+    tag = TinyTag.get(os.path.join(testfolder, 'samples/id3image_without_description.mp3'),
+                      image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 28600 < len(image_data) < 28700, 'Image is %d bytes but should be around 28.6kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 28600 < len(image_data) < 28700, ('Image is %d bytes but should be around 28.6kb' %
+                                             len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_mp3_image_loading_with_utf8_description():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/image-text-encoding.mp3'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 5700 < len(image_data) < 6000, 'Image is %d bytes but should be around 6kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 5700 < len(image_data) < 6000, ('Image is %d bytes but should be around 6kb' %
+                                           len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_mp3_image_loading2():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/12oz.mp3'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 2000 < len(image_data) < 2500, 'Image is %d bytes but should be around 145kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 2000 < len(image_data) < 2500, ('Image is %d bytes but should be around 145kb' %
+                                           len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_mp3_utf_8_invalid_string_raises_exception():
     with raises(TinyTagException):
-        tag = TinyTag.get(os.path.join(testfolder, 'samples/utf-8-id3v2-invalid-string.mp3'))
+        TinyTag.get(os.path.join(testfolder, 'samples/utf-8-id3v2-invalid-string.mp3'))
+
 
 def test_mp3_utf_8_invalid_string_can_be_ignored():
-    tag = TinyTag.get(os.path.join(testfolder, 'samples/utf-8-id3v2-invalid-string.mp3'), ignore_errors=True)
-    # the title used to be Gran dia, but I replaced the first byte with 0xFF, which should be ignored here
+    tag = TinyTag.get(os.path.join(testfolder, 'samples/utf-8-id3v2-invalid-string.mp3'),
+                      ignore_errors=True)
+    # the title used to be Gran dia, but I replaced the first byte with 0xFF,
+    # which should be ignored here
     assert tag.title == 'ran día'
+
 
 def test_mp4_image_loading():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/iso8859_with_image.m4a'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 20000 < len(image_data) < 25000, 'Image is %d bytes but should be around 22kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 20000 < len(image_data) < 25000, ('Image is %d bytes but should be around 22kb' %
+                                             len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_flac_image_loading():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/flac_with_image.flac'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 70000 < len(image_data) < 80000, 'Image is %d bytes but should be around 75kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 70000 < len(image_data) < 80000, ('Image is %d bytes but should be around 75kb' %
+                                             len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 def test_aiff_image_loading():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/test_with_image.aiff'), image=True)
     image_data = tag.get_image()
     assert image_data is not None
-    assert 15000 < len(image_data) < 25000, 'Image is %d bytes but should be around 20kb' % len(image_data)
-    assert image_data.startswith(b'\xff\xd8\xff\xe0'), 'The image data must start with a jpeg header'
+    assert 15000 < len(image_data) < 25000, ('Image is %d bytes but should be around 20kb' %
+                                             len(image_data))
+    assert image_data.startswith(b'\xff\xd8\xff\xe0'), ('The image data must start with a jpeg '
+                                                        'header')
+
 
 @pytest.mark.parametrize("testfile,expected", [
     pytest.param(testfile, expected) for testfile, expected in [
@@ -335,6 +599,7 @@ def test_detect_magic_headers(testfile, expected):
         parser = TinyTag.get_parser_class(filename, fh)
     assert parser == expected
 
+
 def test_show_hint_for_wrong_usage():
     with pytest.raises(Exception) as exc_info:
         TinyTag('filename.mp3', 0)
@@ -346,4 +611,10 @@ def test_to_str():
     tag = TinyTag.get(os.path.join(testfolder, 'samples/id3v22-test.mp3'))
     assert str(tag)  # since the dict is not ordered we cannot == 'somestring'
     assert repr(tag)  # since the dict is not ordered we cannot == 'somestring'
-    assert str(tag) == '{"album": "Hymns for the Exiled", "albumartist": null, "artist": "Anais Mitchell", "audio_offset": 2225, "bitrate": 160.0, "channels": 2, "comment": "Waterbug Records, www.anaismitchell.com", "composer": null, "disc": null, "disc_total": null, "duration": 0.13836297152858082, "extra": {}, "filesize": 5120, "genre": null, "samplerate": 44100, "title": "cosmic american", "track": "3", "track_total": "11", "year": "2004"}'
+    assert str(tag) == (
+        '{"album": "Hymns for the Exiled", "albumartist": null, "artist": "Anais Mitchell", '
+        '"audio_offset": 2225, "bitrate": 160.0, "channels": 2, "comment": "Waterbug Records, '
+        'www.anaismitchell.com", "composer": null, "disc": null, "disc_total": null, '
+        '"duration": 0.13836297152858082, "extra": {}, "filesize": 5120, "genre": null, '
+        '"samplerate": 44100, "title": "cosmic american", "track": "3", "track_total": "11", '
+        '"year": "2004"}')

--- a/tinytag/tests/test_cli.py
+++ b/tinytag/tests/test_cli.py
@@ -36,7 +36,8 @@ def test_print_help():
     assert 'tinytag [options] <filename' in run_cli('--help')
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="NamedTemporaryFile cant be reopened on windows")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="NamedTemporaryFile cant be reopened on windows")
 def test_save_image_long_opt():
     temp_file = NamedTemporaryFile()
     assert file_size(temp_file.name) == 0
@@ -48,7 +49,8 @@ def test_save_image_long_opt():
         assert b'JFIF' in image_data
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="NamedTemporaryFile cant be reopened on windows")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="NamedTemporaryFile cant be reopened on windows")
 def test_save_image_short_opt():
     temp_file = NamedTemporaryFile()
     assert file_size(temp_file.name) == 0
@@ -56,7 +58,8 @@ def test_save_image_short_opt():
     assert file_size(temp_file.name) > 0
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="NamedTemporaryFile cant be reopened on windows")
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="NamedTemporaryFile cant be reopened on windows")
 def test_save_image_bulk():
     temp_file = NamedTemporaryFile(suffix='.jpg')
     temp_file_no_ext = temp_file.name[:-4]

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -30,25 +30,24 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-
-import aifc
-import json
-import operator
+from __future__ import division, print_function
 from chunk import Chunk
 from collections import OrderedDict, defaultdict
 try:
     from collections.abc import MutableMapping
 except ImportError:
     from collections import MutableMapping
-import codecs
 from functools import reduce
-import struct
-import os
-import io
-import sys
 from io import BytesIO
+import aifc
+import codecs
+import io
+import json
+import operator
+import os
 import re
+import struct
+import sys
 
 DEBUG = os.environ.get('DEBUG', False)  # some of the parsers can print debug info
 
@@ -174,7 +173,8 @@ class TinyTag(object):
         raise TinyTagException('No tag reader found to support filetype! ')
 
     @classmethod
-    def get(cls, filename, tags=True, duration=True, image=False, ignore_errors=False, encoding=None):
+    def get(cls, filename, tags=True, duration=True, image=False, ignore_errors=False,
+            encoding=None):
         try:  # cast pathlib.Path to str
             import pathlib
             if isinstance(filename, pathlib.Path):
@@ -270,7 +270,8 @@ class TinyTag(object):
 
 
 class MP4(TinyTag):
-    # see: https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/Metadata/Metadata.html
+    # see: https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/Metadata/
+    # Metadata.html
     # and: https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html
 
     class Parser:
@@ -359,7 +360,7 @@ class MP4(TinyTag):
             # Decoder Config Descriptor
             cls.read_extended_descriptor(esds_atom)
             esds_atom.seek(9, os.SEEK_CUR)
-            avg_br = struct.unpack('>I', esds_atom.read(4))[0] / 1000.0  # kbit/s
+            avg_br = struct.unpack('>I', esds_atom.read(4))[0] / 1000  # kbit/s
             return {'channels': channels, 'samplerate': sr, 'bitrate': avg_br}
 
         @classmethod
@@ -370,7 +371,7 @@ class MP4(TinyTag):
             alac_atom.seek(13, os.SEEK_CUR)
             channels = struct.unpack('b', alac_atom.read(1))[0]
             alac_atom.seek(6, os.SEEK_CUR)
-            avg_br = struct.unpack('>I', alac_atom.read(4))[0] / 1000.0  # kbit/s
+            avg_br = struct.unpack('>I', alac_atom.read(4))[0] / 1000  # kbit/s
             sr = struct.unpack('>I', alac_atom.read(4))[0]
             return {'channels': channels, 'samplerate': sr, 'bitrate': avg_br}
 
@@ -388,7 +389,7 @@ class MP4(TinyTag):
                 walker.seek(16, os.SEEK_CUR)  # jump over create & mod times
                 time_scale = struct.unpack('>I', walker.read(4))[0]
                 duration = struct.unpack('>q', walker.read(8))[0]
-            return {'duration': float(duration) / time_scale}
+            return {'duration': duration / time_scale}
 
         @classmethod
         def debug_atom(cls, data):
@@ -402,16 +403,16 @@ class MP4(TinyTag):
         # see: http://atomicparsley.sourceforge.net/mpeg-4files.html
         b'\xa9alb': {b'data': Parser.make_data_atom_parser('album')},
         b'\xa9ART': {b'data': Parser.make_data_atom_parser('artist')},
-        b'aART':    {b'data': Parser.make_data_atom_parser('albumartist')},
+        b'aART': {b'data': Parser.make_data_atom_parser('albumartist')},
         # b'cpil':    {b'data': Parser.make_data_atom_parser('compilation')},
         b'\xa9cmt': {b'data': Parser.make_data_atom_parser('comment')},
-        b'disk':    {b'data': Parser.make_number_parser('disc', 'disc_total')},
+        b'disk': {b'data': Parser.make_number_parser('disc', 'disc_total')},
         b'\xa9wrt': {b'data': Parser.make_data_atom_parser('composer')},
         b'\xa9day': {b'data': Parser.make_data_atom_parser('year')},
         b'\xa9gen': {b'data': Parser.make_data_atom_parser('genre')},
-        b'gnre':    {b'data': Parser.parse_id3v1_genre},
+        b'gnre': {b'data': Parser.parse_id3v1_genre},
         b'\xa9nam': {b'data': Parser.make_data_atom_parser('title')},
-        b'trkn':    {b'data': Parser.make_number_parser('track', 'track_total')},
+        b'trkn': {b'data': Parser.make_number_parser('track', 'track_total')},
     }}}}}
 
     # see: https://developer.apple.com/library/mac/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html
@@ -453,7 +454,9 @@ class MP4(TinyTag):
                 atom_header = fh.read(header_size)
                 continue
             if DEBUG:
-                stderr('%s pos: %d atom: %s len: %d' % (' ' * 4 * len(curr_path), fh.tell() - header_size, atom_type, atom_size + header_size))
+                stderr('%s pos: %d atom: %s len: %d' %
+                       (' ' * 4 * len(curr_path), fh.tell() - header_size, atom_type,
+                        atom_size + header_size))
             if atom_type in self.VERSIONED_ATOMS:  # jump atom version for now
                 fh.seek(4, os.SEEK_CUR)
             if atom_type in self.FLAGGED_ATOMS:  # jump atom flags for now
@@ -483,12 +486,12 @@ class MP4(TinyTag):
 class ID3(TinyTag):
     FRAME_ID_TO_FIELD = {  # Mapping from Frame ID to a field of the TinyTag
         'COMM': 'comment', 'COM': 'comment',
-        'TRCK': 'track',  'TRK': 'track',
-        'TYER': 'year',   'TYE': 'year',
-        'TALB': 'album',  'TAL': 'album',
+        'TRCK': 'track', 'TRK': 'track',
+        'TYER': 'year', 'TYE': 'year',
+        'TALB': 'album', 'TAL': 'album',
         'TPE1': 'artist', 'TP1': 'artist',
-        'TIT2': 'title',  'TT2': 'title',
-        'TCON': 'genre',  'TCO': 'genre',
+        'TIT2': 'title', 'TT2': 'title',
+        'TCON': 'genre', 'TCO': 'genre',
         'TPOS': 'disc',
         'TPE2': 'albumartist', 'TCOM': 'composer',
         'WXXX': 'extra.url',
@@ -560,7 +563,7 @@ class ID3(TinyTag):
     # see this page for the magic values used in mp3:
     # http://www.mpgedit.org/mpgedit/mpeg_format/mpeghdr.htm
     samplerates = [
-        [11025, 12000,  8000],  # MPEG 2.5
+        [11025, 12000, 8000],   # MPEG 2.5
         [],                     # reserved
         [22050, 24000, 16000],  # MPEG 2
         [44100, 48000, 32000],  # MPEG 1
@@ -625,7 +628,8 @@ class ID3(TinyTag):
             layer_id = (conf >> 1) & 0x03
             channel_mode = (rest >> 6) & 0x03
             # check for eleven 1s, validate bitrate and sample rate
-            if not b[:2] > b'\xFF\xE0' or br_id > 14 or br_id == 0 or sr_id == 3 or layer_id == 0 or mpeg_id == 1:
+            if (not b[:2] > b'\xFF\xE0' or br_id > 14 or br_id == 0 or sr_id == 3
+                    or layer_id == 0 or mpeg_id == 1):  # noqa
                 idx = b.find(b'\xFF', 1)  # invalid frame, find next sync header
                 if idx == -1:
                     idx = len(b)  # not found: jump over the current peek buffer
@@ -646,7 +650,8 @@ class ID3(TinyTag):
                     fh.seek(xing_header_offset, os.SEEK_CUR)
                     xframes, byte_count, toc, vbr_scale = ID3._parse_xing_header(fh)
                     if xframes and xframes != 0 and byte_count:
-                        self.duration = xframes * ID3.samples_per_frame / float(self.samplerate) / self.channels
+                        self.duration = (xframes * ID3.samples_per_frame / self.samplerate
+                                         / self.channels)  # noqa
                         self.bitrate = byte_count * 8 / self.duration / 1000
                         self.audio_offset = fh.tell()
                         return
@@ -663,22 +668,21 @@ class ID3(TinyTag):
             frame_length = (144000 * frame_bitrate) // self.samplerate + padding
             frame_size_accu += frame_length
             # if bitrate does not change over time its probably CBR
-            is_cbr = (frames == ID3._CBR_DETECTION_FRAME_COUNT and
-                      len(set(last_bitrates)) == 1)
+            is_cbr = (frames == ID3._CBR_DETECTION_FRAME_COUNT and len(set(last_bitrates)) == 1)
             if frames == max_estimation_frames or is_cbr:
                 # try to estimate duration
                 fh.seek(-128, 2)  # jump to last byte (leaving out id3v1 tag)
                 audio_stream_size = fh.tell() - self.audio_offset
-                est_frame_count = audio_stream_size / (frame_size_accu / float(frames))
+                est_frame_count = audio_stream_size / (frame_size_accu / frames)
                 samples = est_frame_count * ID3.samples_per_frame
-                self.duration = samples / float(self.samplerate)
+                self.duration = samples / self.samplerate
                 self.bitrate = bitrate_accu / frames
                 return
 
             if frame_length > 1:  # jump over current frame body
                 fh.seek(frame_length - header_bytes, os.SEEK_CUR)
         if self.samplerate:
-            self.duration = frames * ID3.samples_per_frame / float(self.samplerate)
+            self.duration = frames * ID3.samples_per_frame / self.samplerate
 
     def _parse_tag(self, fh):
         self._parse_id3v2(fh)
@@ -737,7 +741,7 @@ class ID3(TinyTag):
     @staticmethod
     def index_utf16(s, search):
         for i in range(0, len(s), len(search)):
-            if s[i:i+len(search)] == search:
+            if s[i:i + len(search)] == search:
                 return i
         return -1
 
@@ -752,9 +756,10 @@ class ID3(TinyTag):
             return 0
         frame = struct.unpack(binformat, frame_header_data)
         frame_id = self._decode_string(frame[0])
-        frame_size = self._calc_size(frame[1:1+frame_size_bytes], bits_per_byte)
+        frame_size = self._calc_size(frame[1:1 + frame_size_bytes], bits_per_byte)
         if DEBUG:
-            stderr('Found id3 Frame %s at %d-%d of %d' % (frame_id, fh.tell(), fh.tell() + frame_size, self.filesize))
+            stderr('Found id3 Frame %s at %d-%d of %d' %
+                   (frame_id, fh.tell(), fh.tell() + frame_size, self.filesize))
         if frame_size > 0:
             # flags = frame[1+frame_size_bytes:] # dont care about flags.
             if frame_id not in ID3.PARSABLE_FRAME_IDS:  # jump over unparsable frames
@@ -766,18 +771,16 @@ class ID3(TinyTag):
                 self._set_field(fieldname, content, self._decode_string)
             elif frame_id in self.IMAGE_FRAME_IDS and self._load_image:
                 # See section 4.14: http://id3.org/id3v2.4.0-frames
+                encoding = content[0:1]
                 if frame_id == 'PIC':  # ID3 v2.2:
-                    encoding, content = content[0], content[1:]
-                    imgformat, content = content[:3], content[3:]
+                    desc_start_pos = 1 + 3 + 1  # skip encoding (1), imgformat (3), pictype(1)
                 else:  # ID3 v2.3+
-                    encoding, content = content[0], content[1:]
-                    mimetype_end_pos = content.index(b'\x00', 1) + 1
-                    mimetype, content = content[:mimetype_end_pos], content[mimetype_end_pos:]
-                pictype, content = content[0], content[1:]
-                termination = b'\x00' if encoding in (0, 3) else b'\x00\x00'  # latin1 and utf-8 are 1 byte
-                desc_end_pos = ID3.index_utf16(content, termination) + len(termination)
-                description, content = content[:desc_end_pos], content[desc_end_pos:]
-                self._image_data = content
+                    desc_start_pos = content.index(b'\x00', 1) + 1 + 1  # skip mimetype, pictype(1)
+                # latin1 and utf-8 are 1 byte
+                termination = b'\x00' if encoding in (b'\x00', b'\x03') else b'\x00\x00'
+                desc_length = ID3.index_utf16(content[desc_start_pos:], termination)
+                desc_end_pos = desc_start_pos + desc_length + len(termination)
+                self._image_data = content[desc_end_pos:]
             return frame_size
         return 0
 
@@ -849,7 +852,7 @@ class Ogg(TinyTag):
             if b[:4] == b'OggS':  # look for an ogg header
                 for _ in self._parse_pages(fh):
                     pass  # parse all remaining pages
-                self.duration = self._max_samplenum / float(self.samplerate)
+                self.duration = self._max_samplenum / self.samplerate
             else:
                 idx = b.find(b'OggS')  # try to find header in peeked data
                 seekpos = idx if idx != -1 else len(b) - 3
@@ -863,7 +866,7 @@ class Ogg(TinyTag):
                 (channels, self.samplerate, max_bitrate, bitrate,
                  min_bitrate) = struct.unpack("<B4i", packet[11:28])
                 if not self.audio_offset:
-                    self.bitrate = bitrate / 1000.0
+                    self.bitrate = bitrate / 1000
                     self.audio_offset = page_start_pos
             elif packet[0:7] == b"\x03vorbis" and self._parse_tags:
                 walker.seek(7, os.SEEK_CUR)  # jump over header name
@@ -931,7 +934,7 @@ class Ogg(TinyTag):
             self._max_samplenum = max(self._max_samplenum, pos)
             if oggs != b'OggS' or version != 0:
                 raise TinyTagException('Not a valid ogg file!')
-            segsizes = struct.unpack('B'*segments, fh.read(segments))
+            segsizes = struct.unpack('B' * segments, fh.read(segments))
             total = 0
             for segsize in segsizes:  # read all segments
                 total += segsize
@@ -986,12 +989,12 @@ class Wave(TinyTag):
                     # Certain codecs (e.g. GSM 6.10) give us a bit depth of zero.
                     # Avoid division by zero when calculating duration.
                     bitdepth = 1
-                self.bitrate = self.samplerate * self.channels * bitdepth / 1000.0
+                self.bitrate = self.samplerate * self.channels * bitdepth / 1000
                 remaining_size = subchunksize - 16
                 if remaining_size > 0:
                     fh.seek(remaining_size, 1)  # skip remaining data in chunk
             elif subchunkid == b'data':
-                self.duration = float(subchunksize) / self.channels / self.samplerate / (bitdepth / 8)
+                self.duration = subchunksize / self.channels / self.samplerate / (bitdepth / 8)
                 self.audio_offset = fh.tell() - 8  # rewind to data header
                 fh.seek(subchunksize, 1)
             elif subchunkid == b'LIST' and self._parse_tags:
@@ -1085,7 +1088,7 @@ class Flac(TinyTag):
                 # bit_depth = (bit_depth + 1)
                 total_sample_bytes = [(header[7] & 0x0F)] + list(header[8:12])
                 total_samples = _bytes_to_int(total_sample_bytes)
-                self.duration = float(total_samples) / self.samplerate
+                self.duration = total_samples / self.samplerate
                 if self.duration > 0:
                     self.bitrate = self.filesize / self.duration * 8 / 1000
             elif block_type == Flac.METADATA_VORBIS_COMMENT and self._parse_tags:
@@ -1095,9 +1098,9 @@ class Flac(TinyTag):
             elif block_type == Flac.METADATA_PICTURE and self._load_image:
                 # https://xiph.org/flac/format.html#metadata_block_picture
                 pic_type, mime_len = struct.unpack('>2I', fh.read(8))
-                mime = fh.read(mime_len)
+                fh.read(mime_len)
                 description_len = struct.unpack('>I', fh.read(4))[0]
-                description = fh.read(description_len)
+                fh.read(description_len)
                 width, height, depth, colors, pic_len = struct.unpack('>5I', fh.read(20))
                 self._image_data = fh.read(pic_len)
             elif block_type >= 127:
@@ -1114,7 +1117,8 @@ class Flac(TinyTag):
 
 class Wma(TinyTag):
     ASF_CONTENT_DESCRIPTION_OBJECT = b'3&\xb2u\x8ef\xcf\x11\xa6\xd9\x00\xaa\x00b\xcel'
-    ASF_EXTENDED_CONTENT_DESCRIPTION_OBJECT = b'@\xa4\xd0\xd2\x07\xe3\xd2\x11\x97\xf0\x00\xa0\xc9^\xa8P'
+    ASF_EXTENDED_CONTENT_DESCRIPTION_OBJECT = (b'@\xa4\xd0\xd2\x07\xe3\xd2\x11\x97\xf0\x00'
+                                               b'\xa0\xc9^\xa8P')
     STREAM_BITRATE_PROPERTIES_OBJECT = b'\xceu\xf8{\x8dF\xd1\x11\x8d\x82\x00`\x97\xc9\xa2\xb2'
     ASF_FILE_PROPERTY_OBJECT = b'\xa1\xdc\xab\x8cG\xa9\xcf\x11\x8e\xe4\x00\xc0\x0c Se'
     ASF_STREAM_PROPERTIES_OBJECT = b'\x91\x07\xdc\xb7\xb7\xa9\xcf\x11\x8e\xe6\x00\xc0\x0c Se'
@@ -1167,7 +1171,8 @@ class Wma(TinyTag):
         self.__tag_parsed = True
         guid = fh.read(16)  # 128 bit GUID
         if guid != b'0&\xb2u\x8ef\xcf\x11\xa6\xd9\x00\xaa\x00b\xcel':
-            return  # not a valid ASF container! see: http://www.garykessler.net/library/file_sigs.html
+            # not a valid ASF container! see: http://www.garykessler.net/library/file_sigs.html
+            return
         struct.unpack('Q', fh.read(8))[0]  # size
         struct.unpack('I', fh.read(4))[0]  # obj_count
         if fh.read(2) != b'\x01\x02':
@@ -1206,7 +1211,8 @@ class Wma(TinyTag):
                     'WM/AlbumTitle': 'album',
                     'WM/Composer': 'composer',
                 }
-                # see: http://web.archive.org/web/20131203084402/http://msdn.microsoft.com/en-us/library/bb643323.aspx#_Toc509555195
+                # see: http://web.archive.org/web/20131203084402/http://msdn.microsoft.com/en-us/
+                # library/bb643323.aspx#_Toc509555195
                 descriptor_count = _bytes_to_int_le(fh.read(2))
                 for _ in range(descriptor_count):
                     name_len = _bytes_to_int_le(fh.read(2))
@@ -1234,7 +1240,8 @@ class Wma(TinyTag):
                 ])
                 # According to the specification, we need to subtract the preroll from play_duration
                 # to get the actual duration of the file
-                self.duration = max(blocks.get('play_duration') / float(10000000) - blocks.get('preroll') / float(1000), 0.0)
+                preroll = blocks.get('preroll') / 1000
+                self.duration = max(blocks.get('play_duration') / 10000000 - preroll, 0.0)
             elif object_id == Wma.ASF_STREAM_PROPERTIES_OBJECT:
                 blocks = self.read_blocks(fh, [
                     ('stream_type', 16, False),
@@ -1256,7 +1263,7 @@ class Wma(TinyTag):
                         ('bits_per_sample', 2, True),
                     ])
                     self.samplerate = stream_info['samples_per_second']
-                    self.bitrate = stream_info['avg_bytes_per_second'] * 8 / float(1000)
+                    self.bitrate = stream_info['avg_bytes_per_second'] * 8 / 1000
                     already_read = 16
                 fh.seek(blocks['type_specific_data_length'] - already_read, os.SEEK_CUR)
                 fh.seek(blocks['error_correction_data_length'], os.SEEK_CUR)
@@ -1309,8 +1316,8 @@ class Aiff(ID3):
         aiffobj = aifc.open(fh, 'rb')
         self.channels = aiffobj.getnchannels()
         self.samplerate = aiffobj.getframerate()
-        self.duration = float(aiffobj.getnframes()) / float(self.samplerate)
-        self.bitrate = self.samplerate * self.channels * aiffobj.getsampwidth() * 8 / 1000.0
+        self.duration = aiffobj.getnframes() / self.samplerate
+        self.bitrate = self.samplerate * self.channels * aiffobj.getsampwidth() * 8 / 1000
 
     def _parse_tag(self, fh):
         fh.seek(0, 0)


### PR DESCRIPTION
Partially implements #138

@devsnd I've tested the GitHub Actions workflow in my personal fork, but you'll have to enable it for the main repo. Coveralls could be reintroduced fairly easily with https://github.com/marketplace/actions/coveralls-github-action, but this is something you would have to set up.

This PR also includes minor fixes for Python 2.7 compatibility. Python 2.7 support will be dropped soon (https://github.com/devsnd/tinytag/issues/98), but it would be good to release a fully functional, final version before that.