### PR TITLE
Add Coveralls to GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         exclude:
           - os: macos-latest
             python: 'pypy-3.6'  # Not installable
@@ -32,3 +32,14 @@ jobs:
 
       - name: Unit tests
         run: python -m pytest --cov
+
+      - name: Coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
+        run: coverage lcov
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.10'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage.lcov


### PR DESCRIPTION
Since travis-ci.org is dead, we can integrate Coveralls with our GitHub Actions workflow instead.

I can't test this PR, since the GitHub token needs to be added to the tinytag Coveralls project, but it should work.