### PR TITLE
Add recognition of Audible formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Features:
     * OPUS
     * FLAC
     * WMA
-    * MP4/M4A/M4B/M4R/M4V/ALAC
+    * MP4/M4A/M4B/M4R/M4V/ALAC/AAX/AAXC
     * AIFF/AIFF-C
   * pure python, no dependencies
   * supports python 2.7 and 3.4 or higher

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -131,7 +131,7 @@ class TinyTag(object):
             (b'.wav',): Wave,
             (b'.flac',): Flac,
             (b'.wma',): Wma,
-            (b'.m4b', b'.m4a', b'.m4r', b'.m4v', b'.mp4'): MP4,
+            (b'.m4b', b'.m4a', b'.m4r', b'.m4v', b'.mp4', b'.aax', b'.aaxc'): MP4,
             (b'.aiff', b'.aifc', b'.aif', b'.afc'): Aiff,
         }
         if not isinstance(filename, bytes):  # convert filename to binary
@@ -151,8 +151,8 @@ class TinyTag(object):
             b'^fLaC': Flac,
             b'^\x30\x26\xB2\x75\x8E\x66\xCF\x11\xA6\xD9\x00\xAA\x00\x62\xCE\x6C': Wma,
             b'....ftypM4A': MP4,  # https://www.file-recovery.com/m4a-signature-format.htm
-            b'....ftypaaxc': MP4,
-            b'....ftypaax': MP4,
+            b'....ftypaax': MP4,  # Audible proprietary M4A container
+            b'....ftypaaxc': MP4,  # Audible proprietary M4A container
             b'\xff\xf1': MP4,  # https://www.garykessler.net/library/file_sigs.html
             b'^FORM....AIFF': Aiff,
             b'^FORM....AIFC': Aiff,

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -151,6 +151,8 @@ class TinyTag(object):
             b'^fLaC': Flac,
             b'^\x30\x26\xB2\x75\x8E\x66\xCF\x11\xA6\xD9\x00\xAA\x00\x62\xCE\x6C': Wma,
             b'....ftypM4A': MP4,  # https://www.file-recovery.com/m4a-signature-format.htm
+            b'....ftypaaxc': MP4,
+            b'....ftypaax': MP4,
             b'\xff\xf1': MP4,  # https://www.garykessler.net/library/file_sigs.html
             b'^FORM....AIFF': Aiff,
             b'^FORM....AIFC': Aiff,


### PR DESCRIPTION
Audible has two proprietary mp4 containers, aax and aaxc. They're standard in every way, except the audio is encrypted. Metadata can still be read.