### PR TITLE
Add missing typing metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ classifiers =
   Topic :: Multimedia
   Topic :: Multimedia :: Sound/Audio
   Topic :: Multimedia :: Sound/Audio :: Analysis
+  Typing :: Typed
 license = MIT
 license_files = LICENSE
 long_description = file: README.md


### PR DESCRIPTION
Add a `py.typed` file and the PyPI classifier, without the former file tools like `mypy` will think that the library is not typed and raise errors along the line of: `Skipping analyzing "tinytag": module is installed, but missing library stubs or py.typed marker [import-untyped]`
