### PR TITLE
Generate code coverage reports with GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@
 name: Tests
 on: [push, pull_request]
 permissions: {}
+env:
+  MIN_COVERAGE_PERCENTAGE: 100
 
 jobs:
   tests:
@@ -49,9 +51,15 @@ jobs:
         run: python -m pyright
 
       - name: Unit tests
-        run: python -m coverage run -m unittest
+        run: python -m coverage run --parallel-mode -m unittest
         env:
           TINYTAG_DEBUG: true
+
+      - name: Coverage report
+        run: |
+          coverage combine --keep --quiet
+          coverage report
+          coverage html --quiet
 
       - name: Build package
         run: python -m build
@@ -59,19 +67,47 @@ jobs:
       - name: Build package without isolation
         run: python -m build --no-isolation
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
         with:
-          flag-name: run-${{ join(matrix.*, '-') }}
-          file: .coverage
-          parallel: true
+          name: coverage-${{ matrix.os }}-${{ matrix.python }}
+          include-hidden-files: true
+          path: |
+            .coverage.*
+            htmlcov
 
-  finish:
+  coverage:
     needs: tests
-    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls finished
-        uses: coverallsapp/github-action@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
         with:
-          parallel-finished: true
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Set up cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: coverage
+
+      - name: Install dependencies
+        run: python -m pip install coverage
+
+      - name: Generate coverage report
+        run: |
+          coverage combine --quiet
+          coverage html --quiet
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-coverage-report
+          path: htmlcov
+
+      - name: Show coverage report
+        run: coverage report --fail-under=${MIN_COVERAGE_PERCENTAGE}

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ tinytag is a Python library for reading audio file metadata
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/tinytag/tinytag/tests.yml
 )](https://github.com/tinytag/tinytag/actions?query=workflow:%22Tests%22)
-[![Coverage Status](https://img.shields.io/coverallsCoverage/github/tinytag/tinytag
-)](https://coveralls.io/r/tinytag/tinytag)
 [![PyPI Version](https://img.shields.io/pypi/v/tinytag
 )](https://pypi.org/project/tinytag/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/tinytag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,3 +120,8 @@ strict = true
 exclude_lines = [
     "if TYPE_CHECKING:"
 ]
+precision = 2
+show_missing = true
+
+[tool.coverage.run]
+relative_files = true


### PR DESCRIPTION
This replaces Coveralls, which we've had issues with for a while (timeouts and outages), and removes the need for a third-party service. Coverage reports are uploaded as job artifacts in HTML format, and a summary is included in the logs.