### PR TITLE
Add option to disable magic header detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,20 @@ if fish_images:
     description = image.description
 ```
 
+### Magic Header Detection
+
+By default, tinytag will determine the file type by 1. checking the file name
+extension, and 2. reading and inspecting the file header, i.e. magic header
+detection.
+
+In case you want to disable magic header detection, e.g. to minimize read
+operations when many non-audio files exist in a folder, pass a
+`header_detection` argument with a value of `False` (added in tinytag 2.3.0).
+
+```python
+tag: TinyTag = TinyTag.get('invalid_file.jpg', header_detection=False)
+```
+
 ### Encoding
 
 To open files using a specific encoding, you can use the `encoding` parameter.
@@ -371,7 +385,7 @@ This parameter is however only used for formats where the encoding is not
 explicitly specified.
 
 ```python
-TinyTag.get('a_file_with_gbk_encoding.mp3', encoding='gbk')
+tag: TinyTag = TinyTag.get('a_file_with_gbk_encoding.mp3', encoding='gbk')
 ```
 
 ### File-like Objects
@@ -380,7 +394,7 @@ To use a file-like object (e.g. BytesIO) instead of a file path, pass a
 `file_obj` keyword argument:
 
 ```python
-TinyTag.get(file_obj=your_file_obj)
+tag: TinyTag = TinyTag.get(file_obj=your_file_obj)
 ```
 
 ### Exceptions

--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -1953,6 +1953,12 @@ class TestAll(TestCase):
                 tag = TinyTag.get(filename)
                 self.assertIsInstance(tag, expected)
 
+            with self.subTest(testfile=testfile, expected=expected):
+                filename = os.path.join(SAMPLE_FOLDER, testfile)
+                with self.assertRaises(UnsupportedFormatError) as context:
+                    TinyTag.get(filename, header_detection=False)
+                self.assertIsInstance(context.exception, TinyTagException)
+
     def test_show_hint_for_wrong_usage(self) -> None:
         with self.assertRaises(ValueError) as context:
             TinyTag.get()

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -119,7 +119,8 @@ class TinyTag:
             duration: bool = True,
             image: bool = False,
             encoding: str | None = None,
-            ignore_errors: bool | None = None) -> TinyTag:
+            ignore_errors: bool | None = None,
+            header_detection: bool = True) -> TinyTag:
         """Return a tag object for an audio file."""
         should_close_file = file_obj is None
         filename_str = None
@@ -141,7 +142,10 @@ class TinyTag:
             file_obj.seek(0, SEEK_END)
             filesize = file_obj.tell()
             file_obj.seek(0)
-            parser_class = cls._get_parser_class(filename_str, file_obj)
+            if header_detection:
+                parser_class = cls._get_parser_class(filename_str, file_obj)
+            else:
+                parser_class = cls._get_parser_class(filename_str)
             tag = parser_class()
             tag._filehandler = file_obj
             tag._default_encoding = encoding
@@ -248,7 +252,7 @@ class TinyTag:
             parser_class = cls._get_parser_for_filename(filename)
             if parser_class is not None:
                 return parser_class
-        # try determining the file type by magic byte header
+        # try determining the file type by magic byte header, if provided
         if filehandle:
             parser_class = cls._get_parser_for_file_handle(filehandle)
             if parser_class is not None:


### PR DESCRIPTION
This is useful in cases where you want to minimize read operations, e.g. when many non-audio files exist in a folder.