### PR TITLE
Images: fix wrong key when storing duplicate named image fields

### DIFF
--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -16,7 +16,7 @@ from sys import stdout
 from unittest import skipIf, TestCase
 
 from tinytag import ParseError, TinyTagException, UnsupportedFormatError
-from tinytag import Images, OtherFields, TinyTag
+from tinytag import Image, Images, OtherFields, TinyTag
 from tinytag.tinytag import _ID3, _MPEG, _Ogg, _Wave, _Flac, _Wma, _MP4, _Aiff
 
 TYPE_CHECKING = False
@@ -2101,6 +2101,22 @@ class TestAll(TestCase):
             "\\xe2\\x02\\xb0ICC_PROFILE\\x00\\x01\\x01\\x00\\x00\\x02"
             "\\xa0lcm..', mime_type='image/jpeg', description='some image ë')"
         )
+
+    def test_images_duplicate_named_field_stored_with_correct_key(
+            self) -> None:
+        # When a named image field (e.g. front_cover) already has a value,
+        # additional images must be stored in `other` under the original field
+        # name, not under a truncated key produced by stripping len('other.')
+        # bytes from a name that doesn't start with 'other.'.
+        for fieldname in ('front_cover', 'back_cover', 'media'):
+            with self.subTest(fieldname=fieldname):
+                imgs = Images()
+                img1 = Image(fieldname, b'data1', 'image/jpeg')
+                img2 = Image(fieldname, b'data2', 'image/jpeg')
+                imgs._set_field(fieldname, img1)
+                imgs._set_field(fieldname, img2)
+                self.assertEqual(list(imgs.other.keys()), [fieldname])
+                self.assertEqual(imgs.other[fieldname][0].data, b'data2')
 
     def test_detect_magic_headers(self) -> None:
         for testfile, expected in (

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -411,7 +411,8 @@ class Images:
     def _set_field(self, fieldname: str, value: Image) -> None:
         old_value = self.__dict__.get(fieldname)
         if fieldname.startswith(self._OTHER_PREFIX) or old_value is not None:
-            fieldname = fieldname[len(self._OTHER_PREFIX):]
+            if fieldname.startswith(self._OTHER_PREFIX):
+                fieldname = fieldname[len(self._OTHER_PREFIX):]
             other_values = self.other.get(fieldname, [])
             other_values.append(value)
             if _DEBUG:


### PR DESCRIPTION
## Bug

`Images._set_field` unconditionally strips `len('other.') == 6` bytes
from `fieldname` before using it as a key in `self.other`, even when
`fieldname` does **not** start with `'other.'`.

This happens whenever a named slot (`front_cover`, `back_cover`,
`media`) already holds an image and a second one is added.  The
resulting keys in `self.other` are wrong:

| Field       | Actual key stored | Expected key |
|-------------|-------------------|--------------|
| `front_cover` | `'cover'`       | `'front_cover'` |
| `back_cover`  | `'over'`        | `'back_cover'`  |
| `media`       | `''`            | `'media'`       |

A caller using `images.other['front_cover']` to retrieve a duplicate
cover image would get a `KeyError`; `images.as_dict()` would show the
wrong key.

## Fix

Only strip the `'other.'` prefix when `fieldname` actually starts with
it; for plain named fields that are already occupied, use `fieldname`
as-is.

```diff
-            fieldname = fieldname[len(self._OTHER_PREFIX):]
+            if fieldname.startswith(self._OTHER_PREFIX):
+                fieldname = fieldname[len(self._OTHER_PREFIX):]
```

A regression test covering all three named image slots is included.

---
This pull request was prepared with the assistance of AI, under my direction and review.