### PR TITLE
fix: avoid OSError when sniffing short MPEG headers

### DIFF
--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -2135,6 +2135,21 @@ class TestAll(TestCase):
                     TinyTag.get(filename, header_detection=False)
                 self.assertIsInstance(context.exception, TinyTagException)
 
+    def test_short_mpeg_header_file_does_not_oserror(self) -> None:
+        """Path-backed files shorter than ID3v1 must still sniff as MPEG."""
+        import tempfile
+        for payload in (b'\xff\xfb', b'\xff\xfb' + b'\x00' * 10):
+            with self.subTest(size=len(payload)):
+                with tempfile.NamedTemporaryFile(delete=False) as handle:
+                    handle.write(payload)
+                    path = handle.name
+                try:
+                    tag = TinyTag.get(path)
+                    self.assertIsInstance(tag, _MPEG)
+                    self.assertEqual(tag.filesize, len(payload))
+                finally:
+                    os.unlink(path)
+
     def test_show_hint_for_wrong_usage(self) -> None:
         with self.assertRaises(ValueError) as context:
             TinyTag.get()

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -226,11 +226,16 @@ class TinyTag:
         if header.startswith(b'ID3'):
             return _ID3
         if header.startswith(b'\xff\xfb'):
-            filehandle.seek(-_ID3._ID3V1_TAG_SIZE, SEEK_END)
-            footer = filehandle.read(3)
-            filehandle.seek(0)
-            if footer == b'TAG':
-                return _ID3
+            # ID3v1 is always 128 bytes; short files must not SEEK_END past start.
+            filehandle.seek(0, SEEK_END)
+            if filehandle.tell() >= _ID3._ID3V1_TAG_SIZE:
+                filehandle.seek(-_ID3._ID3V1_TAG_SIZE, SEEK_END)
+                footer = filehandle.read(3)
+                filehandle.seek(0)
+                if footer == b'TAG':
+                    return _ID3
+            else:
+                filehandle.seek(0)
             return _MPEG
         if header.startswith(b'fLaC'):
             return _Flac


### PR DESCRIPTION
TinyTag._get_parser_for_file_handle hits OSError when short ff fb header seek -128 SEEK_END on path. This PR fixes the regression with a focused test covering the case.
