### PR TITLE
Add 'is_lossless' attribute to indicate lossless audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ $ python3 -m tinytag /some/music.mp3
   "filename": "/some/music.mp3",
   "filesize": 3243226,
   "mime_type": "audio/mpeg",
+  "is_lossless": false,
   "duration": 173.52,
   "channels": 2,
   "bitrate": 128,
@@ -127,10 +128,11 @@ These are helpful when you need quick access to common metadata.
 ```python
 tag.filename: str | None         # file name
 tag.filesize: int                # file size in bytes
-tag.bitdepth: int | None         # audio bit depth (for lossless audio)
+tag.bitdepth: int | None         # audio bit depth
 tag.bitrate: float | None        # audio bitrate in kbps
 tag.channels: int | None         # number of audio channels
 tag.duration: float | None       # audio duration in seconds
+tag.is_lossless: bool | None     # is audio lossless? (added in tinytag 2.3.0)
 tag.mime_type: str | None        # audio MIME type (added in tinytag 2.3.0) 
 tag.samplerate: int | None       # audio samples per second
 ```

--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -34,6 +34,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('vbri.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'duration': 0.47020408163265304,
@@ -50,6 +51,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('cbr.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'duration': 0.4963265306122449,
@@ -66,6 +68,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('vbr_xing_header.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'bitrate': 186.04383278145696,
         'channels': 1,
         'samplerate': 44100,
@@ -80,6 +83,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'tlen': ['249976']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2000,
         'album': "The Harpers' Masque",
         'artist': 'Knodel and Valencia',
@@ -104,6 +108,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'itunes_cddb_tracknumber': ['3'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'track_total': 11,
@@ -120,6 +125,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('silence-44-s-v1.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'genre': 'Darkwave',
@@ -135,6 +141,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('id3v1-latin1.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'genre': 'Rock',
         'album': 'The Young Americans',
         'title': 'Play Dead',
@@ -170,6 +177,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'track_total': 11,
         'track': 7,
         'artist': 'The National',
@@ -183,6 +191,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('utf-8-id3v2.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'genre': 'Acustico',
         'track_total': 21,
         'track': 1,
@@ -196,6 +205,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('utf-8-id3v2-invalid-string.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'genre': 'Acustico',
         'track_total': 21,
         'track': 1,
@@ -213,11 +223,13 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('incomplete.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 3
     }),
     ('silence-44khz-56k-mono-1s.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 1,
         'samplerate': 44100,
         'duration': 1.0448979591836736,
@@ -227,6 +239,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('silence-22khz-mono-1s.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 1,
         'samplerate': 22050,
         'filesize': 4284,
@@ -241,6 +254,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ]
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'track': 1,
         'disc_total': 1,
         'composer': 'Courtney Barnett',
@@ -258,6 +272,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('utf16be.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'title': '52-girls',
         'filesize': 2048,
         'track': 6,
@@ -281,6 +296,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'itunpgap': ['0'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 500,
         'album': 'ARTPOP',
         'artist': 'Lady GaGa',
@@ -296,6 +312,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['LAME 3.97'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 19980,
         'album': 'Ghosts I-IV',
         'albumartist': 'Nine Inch Nails',
@@ -313,6 +330,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'label': ['Unclear']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 512,
         'album': 'The Embrace',
         'artist': 'Johannes Heil & D.Diggler',
@@ -323,6 +341,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('id3_genre_id_out_of_bounds.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 512,
         'album': 'MECHANICAL ANIMALS',
         'artist': 'Manson',
@@ -333,6 +352,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('image-text-encoding.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 1,
         'samplerate': 22050,
         'filesize': 11104,
@@ -346,6 +366,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'publisher': ['Century Media']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1130,
         'album': 'Somewhere Far Beyond',
         'albumartist': 'Blind Guardian',
@@ -360,6 +381,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder_settings': ['Lavf58.20.100']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 80919,
         'channels': 2,
         'duration': 5.067755102040817,
@@ -369,6 +391,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('chinese_id3.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1000,
         'album': '½ÇÂäÖ®¸è',
         'albumartist': 'ËÕÔÆ',
@@ -386,6 +409,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder_settings': ['Lavf54.29.104']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1000,
         'album': 'ERB',
         'artist': 'Epic Rap Battles Of History',
@@ -439,6 +463,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 6943,
         'album': 'eMOTIVe',
         'albumartist': 'A Perfect Circle',
@@ -459,6 +484,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr8.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9504,
         'bitrate': 8.25,
         'channels': 1,
@@ -468,6 +494,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr8stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9504,
         'bitrate': 8.25,
         'channels': 2,
@@ -477,6 +504,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr11.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9360,
         'bitrate': 8.143465909090908,
         'channels': 1,
@@ -486,6 +514,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr11stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9360,
         'bitrate': 8.143465909090908,
         'channels': 2,
@@ -495,6 +524,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr16.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9432,
         'bitrate': 8.251968503937007,
         'channels': 1,
@@ -504,6 +534,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr16stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9432,
         'bitrate': 8.251968503937007,
         'channels': 2,
@@ -513,6 +544,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr22.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9282,
         'bitrate': 8.145021489971347,
         'channels': 1,
@@ -522,6 +554,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr22stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9282,
         'bitrate': 8.145021489971347,
         'channels': 2,
@@ -531,6 +564,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr32.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 37008,
         'bitrate': 32.50592885375494,
         'channels': 1,
@@ -540,6 +574,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr32stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 37008,
         'bitrate': 32.50592885375494,
         'channels': 2,
@@ -549,6 +584,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr44.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 36609,
         'bitrate': 32.21697198275862,
         'channels': 1,
@@ -558,6 +594,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr44stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 36609,
         'bitrate': 32.21697198275862,
         'channels': 2,
@@ -567,6 +604,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr48.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 36672,
         'bitrate': 32.33862433862434,
         'channels': 1,
@@ -576,6 +614,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr48stereo.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 36672,
         'bitrate': 32.33862433862434,
         'channels': 2,
@@ -586,6 +625,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('id3v24_genre_null_byte.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 256,
         'album': '\u79d8\u5bc6',
         'albumartist': 'aiko',
@@ -598,6 +638,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('vbr_xing_header_short.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 432,
         'bitrate': 24.0,
         'channels': 1,
@@ -617,6 +658,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ]
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2007,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -627,6 +669,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     }),
     ('id3_frames.mp3', {
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 27576,
         'bitrate': 50.03636363636364,
         'channels': 1,
@@ -637,12 +680,14 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('id3v22_with_image.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2311,
         'title': 'image',
     }),
     ('utf16_no_bom.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1069,
         'title': 'no bom test ë',
         'artist': 'no bom test 2 ë',
@@ -650,6 +695,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('title_after_image.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2311,
         'title': 'title after image',
         'track': 1,
@@ -659,6 +705,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'grouping': ['some grouping'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2007,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -681,6 +728,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'show_movement': ['1']
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2007,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -698,6 +746,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('empty_frame.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2005,
         'bitrate': 32.0,
         'channels': 1,
@@ -712,6 +761,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
                        'line\n[00:05.99]third line'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2007,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -723,6 +773,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'lyrics': ['\nfirst line\nsecond line\nthird line'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2007,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -737,6 +788,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
                        '[18246:35.58]\n[18246:35.58]\n[18246:35.58]'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 498,
         'bitrate': 128.0,
         'channels': 2,
@@ -752,6 +804,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
                        '[18175:35.68]'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 507,
         'bitrate': 128.0,
         'channels': 2,
@@ -773,6 +826,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
                 'scription>\n </rdf:RDF>\n</x:xmpmeta>'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 5712,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -785,6 +839,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('synced_lyrics_empty.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1988,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -796,6 +851,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'title': ['another title', 'yet another title'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 1988,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -813,6 +869,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'lyrics': ['duplicate lyrics', 'new lyrics', 'more lyrics'],
         }),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 3037,
         'bitrate': 57.39124999999999,
         'channels': 1,
@@ -829,12 +886,14 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('multiple_images.mp3', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 9633,
         'title': 'image',
     }),
     ('empty.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 3.684716553287982,
         'filesize': 4328,
         'bitrate': 112.0,
@@ -850,6 +909,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'replaygain_track_gain': ['-10.02 dB'],
         }),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'genre': 'JRock',
         'duration': 4.128798185941043,
         'album': 'Timeless',
@@ -866,6 +926,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 1.0,
         'album': 'the boss',
         'year': '2006',
@@ -881,6 +942,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('corrupt_metadata.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'filesize': 18648,
         'bitrate': 80.0,
         'duration': 2.132358276643991,
@@ -890,6 +952,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('composer.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'filesize': 4480,
         'album': 'An Album',
         'artist': 'An Artist',
@@ -907,6 +970,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('ogg_with_image.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'channels': 1,
         'duration': 0.1,
         'filesize': 5759,
@@ -925,6 +989,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'show_movement': ['1']
         }),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'channels': 1,
         'duration': 0.1,
         'filesize': 4279,
@@ -942,6 +1007,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('data_after_eos.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 3.684716553287982,
         'filesize': 4424,
         'bitrate': 112.0,
@@ -951,6 +1017,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('no_audio.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 0.0,
         'filesize': 2837,
         'samplerate': 8000,
@@ -961,6 +1028,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder': ['Lavf62.3.100'],
         }),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 30.0,
         'filesize': 9344,
         'bitrate': 16.8,
@@ -970,6 +1038,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('negative_bitrate.ogg', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'duration': 7.6635,
         'filesize': 7224,
         'samplerate': 6000,
@@ -990,6 +1059,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'vocal': ['nomico'],
         }),
         'mime_type': 'audio/ogg; codecs="opus"',
+        'is_lossless': False,
         'albumartist': 'Alstroemeria Records',
         'samplerate': 48000,
         'channels': 2,
@@ -1011,6 +1081,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder': ['opusenc from opus-tools 0.2']
         }),
         'mime_type': 'audio/ogg; codecs="opus"',
+        'is_lossless': False,
         'filesize': 7251,
         'channels': 1,
         'samplerate': 48000,
@@ -1024,6 +1095,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'lyrics': ['test7']
         }),
         'mime_type': 'audio/ogg; codecs="flac"',
+        'is_lossless': True,
         'filesize': 9273,
         'album': 'test2',
         'artist': 'test6',
@@ -1045,6 +1117,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('no_bitrate.spx', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="speex"',
+        'is_lossless': False,
         'filesize': 7921,
         'channels': 1,
         'samplerate': 16000,
@@ -1058,6 +1131,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder': ['Lavc62.11.100 libspeex'],
         }),
         'mime_type': 'audio/ogg; codecs="speex"',
+        'is_lossless': False,
         'filesize': 2304,
         'channels': 1,
         'samplerate': 8000,
@@ -1070,6 +1144,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 1.0,
         'filesize': 176444,
@@ -1080,6 +1155,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test3sMono.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 3.0,
         'filesize': 264644,
@@ -1090,6 +1166,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test-tagged.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 1.0,
         'filesize': 176688,
@@ -1107,6 +1184,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test-riff-tags.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 1.0,
         'filesize': 176540,
@@ -1122,6 +1200,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('silence-22khz-mono-1s.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 0.9991836734693877,
         'filesize': 48160,
@@ -1135,6 +1214,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf58.20.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 1.0,
         'filesize': 44280,
@@ -1149,6 +1229,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('adpcm.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="2"',
+        'is_lossless': False,
         'channels': 1,
         'duration': 12.080136054421768,
         'filesize': 268686,
@@ -1168,6 +1249,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf59.16.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.11609977324263039,
         'filesize': 20670,
@@ -1186,6 +1268,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf59.16.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.11609977324263039,
         'filesize': 20682,
@@ -1203,6 +1286,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             '_disc': ['garbage'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'filesize': 8908,
         'bitrate': 705.6,
         'duration': 0.1,
@@ -1213,6 +1297,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('gsm_6_10.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="49"',
+        'is_lossless': False,
         'bitrate': 72.8,
         'channels': 1,
         'duration': 0.1,
@@ -1229,6 +1314,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('wav_with_image.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 2.144625,
         'filesize': 22902,
@@ -1249,6 +1335,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ]
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'artist': 'some artist',
         'title': 'some title',
         'album': 'some album',
@@ -1262,6 +1349,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('32bit_float.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="3"',
+        'is_lossless': True,
         'bitrate': 512.0,
         'channels': 2,
         'duration': 0.1,
@@ -1272,6 +1360,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('24bit_pcm.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 384.0,
         'channels': 2,
         'duration': 0.1,
@@ -1284,6 +1373,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 384.0,
         'channels': 2,
         'duration': 0.128,
@@ -1294,6 +1384,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('32bit_pcm.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 512.0,
         'channels': 2,
         'duration': 0.1,
@@ -1306,6 +1397,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 512.0,
         'channels': 2,
         'duration': 0.128,
@@ -1318,6 +1410,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="2"',
+        'is_lossless': False,
         'bitrate': 64.7588932806324,
         'channels': 2,
         'duration': 0.1265,
@@ -1330,6 +1423,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="85"',
+        'is_lossless': False,
         'channels': 2,
         'duration': 0.0,
         'filesize': 104,
@@ -1338,6 +1432,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('no_audio_data_uncompressed.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.0,
         'filesize': 44,
@@ -1347,6 +1442,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('8bit_pcm.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 128.0,
         'channels': 2,
         'duration': 0.1,
@@ -1359,6 +1455,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 128.0,
         'channels': 2,
         'duration': 0.128,
@@ -1369,6 +1466,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('16bit_pcm.wav', {
         'other': OtherFields(),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'bitrate': 256.0,
         'channels': 2,
         'duration': 0.1,
@@ -1381,6 +1479,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf61.7.100'],
         }),
         'mime_type': 'audio/wav; codecs="85"',
+        'is_lossless': False,
         'filesize': 4264,
         'samplerate': 44100,
         'duration': 1.0250566893424036,
@@ -1394,6 +1493,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('flac1sMono.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'genre': 'Avantgarde',
         'album': 'alb',
         'year': '2014',
@@ -1411,6 +1511,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('flac453sStereo.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'duration': 453.51473922902494,
         'filesize': 84236,
@@ -1421,6 +1522,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('flac1.5sStereo.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'album': 'alb',
         'year': '2014',
@@ -1450,6 +1552,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'replaygain_album_peak': ['1.0000'],
         }),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'track_total': 11,
         'album': 'Belle and Sebastian Write About Love',
@@ -1466,6 +1569,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('no-tags.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'duration': 3.684716553287982,
         'filesize': 4692,
@@ -1485,6 +1589,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'replaygain_track_peak': ['1.000000'],
         }),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'album': 'Appleseed Original Soundtrack',
         'year': '2004',
@@ -1506,6 +1611,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('106-invalid-streaminfo.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 4692,
         'bitrate': 1.0985919653406853,
         'channels': 2,
@@ -1516,6 +1622,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('106-short-picture-block-size.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 4692,
         'bitrate': 1.0985919653406853,
         'channels': 2,
@@ -1526,6 +1633,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('with_padded_id3_header.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 16070,
         'album': 'album',
         'artist': 'artist',
@@ -1554,6 +1662,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'title': ['title'],
         }),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 19522,
         'album': 'Unbekannter Titel',
         'artist': 'Unbekannter Künstler',
@@ -1574,6 +1683,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('flac_invalid_track_number.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 235,
         'bitrate': 1.92,
         'channels': 1,
@@ -1593,6 +1703,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'url': ['https://example.com'],
         }),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 4749,
         'album': 'album 1',
         'artist': 'artist 1',
@@ -1612,6 +1723,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'lyrics': ['some lyrics here\nnew line']
         }),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'duration': 3.684716553287982,
         'filesize': 4777,
@@ -1626,6 +1738,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('invalid_second_streaminfo.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 273,
         'bitrate': 1.92,
         'channels': 1,
@@ -1637,6 +1750,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('invalid_block_sizes.flac', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'filesize': 295,
         'bitrate': 1.92,
         'channels': 1,
@@ -1660,6 +1774,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'averagelevel': ['7291'],
         }),
         'mime_type': 'audio/x-ms-wma; codecs="353"',
+        'is_lossless': False,
         'samplerate': 44100,
         'album': 'The Colour and the Shape',
         'title': 'Doll',
@@ -1673,10 +1788,12 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
         'genre': 'Alternative',
         'composer': 'Foo Fighters',
         'channels': 2,
+        'bitdepth': 16,
     }),
     ('lossless.wma', {
         'other': OtherFields(),
         'mime_type': 'audio/x-ms-wma; codecs="355"',
+        'is_lossless': True,
         'samplerate': 44100,
         'bitrate': 667.296,
         'filesize': 2500,
@@ -1689,10 +1806,12 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder_settings': ['Lavf60.16.100']
         }),
         'mime_type': 'audio/x-ms-wma; codecs="353"',
+        'is_lossless': False,
         'filesize': 3940,
         'bitrate': 128.0,
         'duration': 2.1409999999999996,
         'samplerate': 44100,
+        'bitdepth': 16,
         'channels': 1,
     }),
     ('grouping.wma', {
@@ -1701,10 +1820,12 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'work': ['some work'],
         }),
         'mime_type': 'audio/x-ms-wma; codecs="353"',
+        'is_lossless': False,
         'filesize': 4070,
         'bitrate': 128.0,
         'duration': 2.1409999999999996,
         'samplerate': 44100,
+        'bitdepth': 16,
         'channels': 1,
         'title': 'some title',
         'album': 'some album',
@@ -1731,10 +1852,12 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoder_settings': ['Lavf60.16.100'],
         }),
         'mime_type': 'audio/x-ms-wma; codecs="353"',
+        'is_lossless': False,
         'filesize': 4723,
         'bitrate': 128.0,
         'duration': 2.1409999999999996,
         'samplerate': 44100,
+        'bitdepth': 16,
         'channels': 1,
         'title': 'some title',
         'album': 'some album',
@@ -1770,6 +1893,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'pgap': ['0'],
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'samplerate': 44100,
         'duration': 314.97868480725623,
         'bitrate': 256.0,
@@ -1790,6 +1914,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf60.3.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'artist': 'test1',
         'composer': 'test8',
         'filesize': 9419,
@@ -1805,6 +1930,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'upc': ['0034571177380']
         }),
         'mime_type': 'audio/mp4; codecs="alac"',
+        'is_lossless': True,
         'artist': 'Howard Shelley',
         'filesize': 20000,
         'composer': 'Clementi, Muzio (1752-1832)',
@@ -1830,6 +1956,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf59.27.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'filesize': 32006,
         'bitrate': 101.038,
         'channels': 2,
@@ -1853,6 +1980,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf60.3.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'artist': 'test1',
         'composer': 'test8',
         'filesize': 6260,
@@ -1864,6 +1992,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('mvhd_version_1.m4a', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.5"',
+        'is_lossless': False,
         'title': '64-bit test',
         'filesize': 2048,
         'samplerate': 44100,
@@ -1881,6 +2010,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'grouping': ['grouping', 'second grouping']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'artist': 'some artist',
         'title': 'some title',
         'album': 'some album',
@@ -1899,6 +2029,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'pgap': ['1'],
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'filesize': 1995,
         'samplerate': 44100,
         'duration': 0.524,
@@ -1915,6 +2046,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'show_movement': ['1'],
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'filesize': 1995,
         'samplerate': 44100,
         'duration': 0.524,
@@ -1935,6 +2067,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf59.27.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'comment': 'test comment',
         'filesize': 32014,
         'samplerate': 44100,
@@ -1966,6 +2099,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf61.7.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'artist': 'some artist',
         'title': 'some title',
         'album': 'some album',
@@ -1980,6 +2114,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf61.7.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.40.2"',
+        'is_lossless': False,
         'artist': 'some artist',
         'title': 'some title',
         'album': 'some album',
@@ -1992,6 +2127,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('8bit_pcm_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 19.76,
         'channels': 2,
         'duration': 0.1,
@@ -2001,6 +2137,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('8bit_pcm_lavf_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 0.125,
         'channels': 2,
         'duration': 0.128,
@@ -2010,6 +2147,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('16bit_pcm_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 23.6,
         'channels': 2,
         'duration': 0.1,
@@ -2019,6 +2157,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('24bit_pcm_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 23.84,
         'channels': 2,
         'duration': 0.1,
@@ -2028,6 +2167,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('24bit_pcm_extended_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 134.812,
         'channels': 2,
         'duration': 0.128,
@@ -2037,6 +2177,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('32bit_pcm_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 0.16,
         'channels': 2,
         'duration': 0.1,
@@ -2046,6 +2187,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('32bit_pcm_extended_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 262.187,
         'channels': 2,
         'duration': 0.128,
@@ -2055,6 +2197,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('32bit_float_to_als.mp4', {
         'other': OtherFields(),
         'mime_type': 'audio/mp4; codecs="mp4a.40.36"',
+        'is_lossless': True,
         'bitrate': 0.64,
         'channels': 2,
         'duration': 0.1,
@@ -2066,6 +2209,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'encoded_by': ['Lavf61.7.100']
         }),
         'mime_type': 'audio/mp4; codecs="mp4a.6B"',
+        'is_lossless': False,
         'filesize': 4922,
         'samplerate': 44100,
         'duration': 1.025,
@@ -2084,6 +2228,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('test-tagged.aiff', {
         'other': OtherFields(),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 1.0,
         'filesize': 177620,
@@ -2103,6 +2248,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'copyright': ['℗ 1992 Ace Records']
         }),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.0,
         'filesize': 164,
@@ -2114,6 +2260,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('pluck-pcm8.aiff', {
         'other': OtherFields(),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.2999546485260771,
         'filesize': 6892,
@@ -2131,6 +2278,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'comment': ['user: kabal@CAPELLA', 'program: CopyAudio']
         }),
         'mime_type': 'audio/aiff; codecs="ulaw"',
+        'is_lossless': False,
         'channels': 2,
         'duration': 2.936625,
         'filesize': 47148,
@@ -2142,6 +2290,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('invalid_sample_rate.aiff', {
         'other': OtherFields(),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 1,
         'filesize': 4096,
         'bitdepth': 16,
@@ -2152,6 +2301,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isrc': ['CC-XXX-YY-NNNNN']
         }),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 2.176,
         'filesize': 18532,
@@ -2164,6 +2314,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('aiff_with_image.aiff', {
         'other': OtherFields(),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 2.176,
         'filesize': 21044,
@@ -2192,6 +2343,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             ]
         }),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.2999546485260771,
         'filesize': 9612,
@@ -2205,6 +2357,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('no_audio.aiff', {
         'other': OtherFields(),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.0,
         'filesize': 54,
@@ -2218,11 +2371,13 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('magic_header_only_id3.x', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 3,
     }),
     ('detect_mp3_id3.x', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'duration': 0.4963265306122449,
@@ -2239,6 +2394,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('detect_mp3_fffb_id3v1.x', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'genre': 'Darkwave',
@@ -2254,6 +2410,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('detect_mp3_fffb.x', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'channels': 2,
         'samplerate': 44100,
         'duration': 3.7355102040816326,
@@ -2263,11 +2420,13 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('magic_header_only_mp3.x', {
         'other': OtherFields(),
         'mime_type': 'audio/mpeg',
+        'is_lossless': False,
         'filesize': 2,
     }),
     ('detect_ogg.x', {
         'other': OtherFields(),
         'mime_type': 'audio/ogg; codecs="vorbis"',
+        'is_lossless': False,
         'filesize': 4480,
         'album': 'An Album',
         'artist': 'An Artist',
@@ -2292,6 +2451,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'isft': ['Lavf58.20.10'],
         }),
         'mime_type': 'audio/wav; codecs="1"',
+        'is_lossless': True,
         'channels': 1,
         'duration': 0.0,
         'filesize': 120,
@@ -2309,6 +2469,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
     ('detect_flac.x', {
         'other': OtherFields(),
         'mime_type': 'audio/flac',
+        'is_lossless': True,
         'channels': 2,
         'duration': 3.684716553287982,
         'filesize': 120,
@@ -2348,6 +2509,7 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
             'copyright': ['℗ 1992 Ace Records']
         }),
         'mime_type': 'audio/aiff; codecs="NONE"',
+        'is_lossless': True,
         'channels': 2,
         'duration': 0.0,
         'filesize': 164,
@@ -2662,7 +2824,8 @@ class TestAll(TestCase):
             with self.subTest(testfile=testfile, expected=expected):
                 filename = os.path.join(SAMPLE_FOLDER, testfile)
                 excluded_attrs = {
-                    'bitdepth', 'bitrate', 'channels', 'duration', 'samplerate'
+                    'bitdepth', 'bitrate', 'channels', 'duration',
+                    'is_lossless', 'samplerate'
                 }
                 tag = TinyTag.get(filename, tags=True, duration=False)
                 results = {
@@ -2687,8 +2850,9 @@ class TestAll(TestCase):
             with self.subTest(testfile=testfile, expected=expected):
                 filename = os.path.join(SAMPLE_FOLDER, testfile)
                 allowed_attrs = {
-                    'mime_type', 'bitdepth', 'bitrate', 'channels', 'duration',
-                    'filesize', 'samplerate'}
+                    'bitdepth', 'bitrate', 'channels', 'duration', 'filesize',
+                    'is_lossless', 'mime_type', 'samplerate'
+                }
                 tag = TinyTag.get(filename, tags=False, duration=True)
                 results = {
                     key: val for key, val in tag.__dict__.items()
@@ -2894,9 +3058,9 @@ class TestAll(TestCase):
         vars_str = str(vars(tag))
         self.assertIn(
             "multiple_values_images.flac', 'filesize': 4749, "
-            "'mime_type': 'audio/flac', 'duration': 0.1, "
-            "'channels': 1, 'bitrate': 1.92, "
-            "'bitdepth': 16, 'samplerate': 44100, 'artist': 'artist 1', "
+            "'mime_type': 'audio/flac', 'is_lossless': True, 'duration': 0.1, "
+            "'channels': 1, 'bitrate': 1.92, 'bitdepth': 16, "
+            "'samplerate': 44100, 'artist': 'artist 1', "
             "'albumartist': None, 'composer': None, 'album': 'album 1', "
             "'disc': 1, 'disc_total': 1, 'title': None, 'track': 1, "
             "'track_total': 1, 'genre': 'genre 1', 'year': None, "
@@ -2943,9 +3107,9 @@ class TestAll(TestCase):
         )
         self.assertIn(
             "multiple_values_images.flac', 'filesize': 4749, "
-            "'mime_type': 'audio/flac', 'duration': 0.1, "
-            "'channels': 1, 'bitrate': 1.92, "
-            "'bitdepth': 16, 'samplerate': 44100, 'artist': ['artist 1', "
+            "'mime_type': 'audio/flac', 'is_lossless': True, 'duration': 0.1, "
+            "'channels': 1, 'bitrate': 1.92, 'bitdepth': 16, "
+            "'samplerate': 44100, 'artist': ['artist 1', "
             "'artist 2', 'artist 3'], 'album': ['album 1', 'album 2'], "
             "'disc': ['1', '2', '3'], 'disc_total': ['1', '2', '3'], "
             "'track': ['1', '2', '3'], 'track_total': ['1', '2', '3'], "

--- a/tinytag/tests/test_cli.py
+++ b/tinytag/tests/test_cli.py
@@ -20,8 +20,8 @@ BOGUS_FILE = os.path.join(SAMPLE_FOLDER, 'there_is_no_such_ext.bogus')
 TINYTAG_ATTRIBUTES = {
     'album', 'albumartist', 'artist', 'bitdepth', 'bitrate',
     'channels', 'comment', 'composer', 'disc', 'disc_total', 'duration',
-    'filesize', 'filename', 'genre', 'mime_type', 'samplerate', 'title',
-    'track', 'track_total', 'year'
+    'filesize', 'filename', 'genre', 'is_lossless', 'mime_type', 'samplerate',
+    'title', 'track', 'track_total', 'year'
 }
 
 

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -89,6 +89,7 @@ class TinyTag:
         self.filesize = 0
 
         self.mime_type: str | None = None
+        self.is_lossless: bool | None = None
         self.duration: float | None = None
         self.channels: int | None = None
         self.bitrate: float | None = None
@@ -181,7 +182,7 @@ class TinyTag:
         metadata."""
         audio_property_keys = {
             'filename', 'filesize', 'mime_type', 'duration', 'channels',
-            'bitrate', 'bitdepth', 'samplerate'
+            'bitrate', 'bitdepth', 'samplerate', 'is_lossless'
         }
         fields: dict[str, str | float | list[str]] = {}
         for key, value in self.__dict__.items():
@@ -516,6 +517,12 @@ class _MP4(TinyTag):
         2: '>h',
         4: '>i',
         8: '>q'
+    }
+    _LOSSLESS_CODECS = {
+        'mp4a.40.35',  # DST
+        'mp4a.40.36',  # ALS
+        'mp4a.40.37',  # SLS
+        'mp4a.40.38',  # SLS non-core
     }
     _VERSIONED_ATOMS = {b'meta', b'stsd'}  # those have an extra 4 byte header
     _FLAGGED_ATOMS = {b'stsd'}  # these also have an extra 4 byte header
@@ -859,6 +866,7 @@ class _MP4(TinyTag):
         if audio_object_type:
             codec += f'.{audio_object_type}'
         yield 'codec', codec
+        yield 'is_lossless', codec in cls._LOSSLESS_CODECS
 
     @classmethod
     def _parse_alac(cls, data: bytes) -> Iterator[tuple[str, str | int]]:
@@ -872,6 +880,7 @@ class _MP4(TinyTag):
         yield 'samplerate', sr
         avg_br /= 1000  # kbit/s
         yield 'bitrate', avg_br
+        yield 'is_lossless', True
 
     @classmethod
     def _parse_mvhd(cls, data: bytes) -> Iterator[tuple[str, float]]:
@@ -1532,6 +1541,7 @@ class _MPEG(TinyTag):
         self.mime_type = 'audio/mpeg'
         if not self._parse_duration:
             return
+        self.is_lossless = False
         max_estimation_frames = (
             (self._MAX_ESTIMATION_SEC * 44100) // self._SAMPLES_PER_FRAME)
         frame_size_accu = 0
@@ -1718,6 +1728,7 @@ class _Ogg(TinyTag):
                     if bitrate > 0:
                         self.bitrate = bitrate / 1000
                     self.mime_type = 'audio/ogg; codecs="vorbis"'
+                    self.is_lossless = False
                     self._granule_pos_serial = serial
                     self._duration_parsed = True
             elif packet.startswith(b'\x03vorbis'):
@@ -1735,6 +1746,7 @@ class _Ogg(TinyTag):
                         self.channels = ch
                         self.samplerate = 48000
                     self.mime_type = 'audio/ogg; codecs="opus"'
+                    self.is_lossless = False
                     self._duration_parsed = True
                     self._granule_pos_serial = serial
             elif packet.startswith(b'OpusTags'):
@@ -1760,6 +1772,7 @@ class _Ogg(TinyTag):
                 self._update(flactag)
                 if self._parse_duration:
                     self.mime_type = 'audio/ogg; codecs="flac"'
+                    self.is_lossless = True
                 self._duration_parsed = self._parse_duration
                 check_flac_second_packet = True
             elif check_flac_second_packet:
@@ -1781,6 +1794,7 @@ class _Ogg(TinyTag):
                     if bitrate > 0:
                         self.bitrate = bitrate / 1000
                     self.mime_type = 'audio/ogg; codecs="speex"'
+                    self.is_lossless = False
                     self._granule_pos_serial = serial
                     self._duration_parsed = True
                 check_speex_second_packet = True
@@ -1961,7 +1975,15 @@ class _Wave(TinyTag):
     }
     _UNCOMPRESSED_FORMATS = {
         0x01,  # PCM
-        0x03,  # IEEE FLOAT
+        0x03,  # IEEE Float
+    }
+    _LOSSLESS_FORMATS = {
+        0x01,    # PCM
+        0x03,    # IEEE Float
+        0x163,   # WMA Lossless
+        0x8ae,   # ClearJump LiteWave (lossless)
+        0x1971,  # Sonic Foundry LOSSLESS
+        0xf1ac,  # FLAC
     }
 
     def _parse(self, fh: BinaryIO) -> None:
@@ -1971,7 +1993,6 @@ class _Wave(TinyTag):
         if not header.startswith(b'RIFF') or not header.startswith(b'WAVE', 8):
             raise ParseError('Invalid WAV header')
         self.mime_type = 'audio/wav'
-        is_compressed = False
         block_align = 0
         audio_size = 0
         num_samples = 0
@@ -1991,7 +2012,7 @@ class _Wave(TinyTag):
                     format_tag = unpack_from('<H', chunk, 24)[0]
                 if bitdepth > 0:
                     self.bitdepth = bitdepth
-                is_compressed = format_tag not in self._UNCOMPRESSED_FORMATS
+                self.is_lossless = format_tag in self._LOSSLESS_FORMATS
                 if format_tag:
                     self.mime_type = f'audio/wav; codecs="{format_tag}"'
             elif self._parse_duration and chunk_header.startswith(b'data'):
@@ -2041,7 +2062,7 @@ class _Wave(TinyTag):
             else:  # some other chunk, just skip the data
                 fh.seek(subchunk_size, SEEK_CUR)
             chunk_header = fh.read(header_len)
-        if is_compressed and self.samplerate:
+        if not self.is_lossless and self.samplerate:
             if not audio_size:
                 # Normalization due to some encoders setting num_samples to 1
                 # when no audio data is present.
@@ -2105,6 +2126,7 @@ class _Flac(TinyTag):
                 total_samples = info_byte & ((1 << 36) - 1)
                 self.duration = total_samples / samplerate
                 self.samplerate = samplerate
+                self.is_lossless = True
             elif block_type == self._VORBIS_COMMENT:
                 # Some files in the wild contain incorrect block sizes for
                 # Vorbis comment blocks. Attempt to parse the block as usual
@@ -2318,8 +2340,8 @@ class _Wma(TinyTag):
                     if format_tag:
                         self.mime_type = (
                             f'audio/x-ms-wma; codecs="{format_tag}"')
-                    if format_tag == 355:  # lossless
-                        self.bitdepth = unpack_from('<H', data, 68)[0]
+                    self.bitdepth = unpack_from('<H', data, 68)[0]
+                    self.is_lossless = (format_tag == 355)
             elif (self._parse_tags
                     and object_header.startswith(self._XMP_METADATA)):
                 value = fh.read(object_size).decode('utf-8', 'replace')
@@ -2359,6 +2381,20 @@ class _Aiff(TinyTag):
         b'AUTH': 'artist',
         b'ANNO': 'comment',
         b'(c) ': 'other.copyright',
+    }
+    _UNCOMPRESSED_FORMATS = {
+        'NONE',
+        'raw ',
+        'twos',
+        'sowt',
+        'in24',
+        '42ni',
+        'in32',
+        '23ni',
+        'fl32',
+        'FL32',
+        'fl64',
+        'FL64',
     }
 
     def _parse(self, fh: BinaryIO) -> None:
@@ -2400,6 +2436,8 @@ class _Aiff(TinyTag):
                     compression_type = 'NONE'  # uncompressed
                 self.mime_type = (
                     f'audio/aiff; codecs="{compression_type}"')
+                self.is_lossless = (
+                    compression_type in self._UNCOMPRESSED_FORMATS)
                 self._duration_parsed = True
                 if not self._parse_tags:
                     break


### PR DESCRIPTION
This is more robust than trying to rely on the presence of a bit depth value. It also allows us to expose the bit depth value provided by the format, even if it's lossy.