### PR TITLE
Speex: Don't read vendor string as comment

### DIFF
--- a/tinytag/tests/test_all.py
+++ b/tinytag/tests/test_all.py
@@ -1425,7 +1425,6 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
         'duration': 2.1445625,
         'artist': 'test1',
         'title': 'test2',
-        'comment': 'Encoded with Speex 1.2.0',
     }),
     ('bitrate_present.spx', {
         'other': OtherFields({
@@ -1440,7 +1439,6 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
         'duration': 1.067,
         'artist': 'test1',
         'title': 'test2',
-        'comment': 'Lavf62.3.100',
     }),
     ('zero_value_properties.ogg', {
         'other': OtherFields(),
@@ -1472,7 +1470,6 @@ TEST_FILES: dict[str, ExpectedTag] = dict([
         'mime_type': 'audio/ogg; codecs="speex"',
         'is_lossless': False,
         'filesize': 2239,
-        'comment': 'Lavf62.3.100',
     }),
     ('test.wav', {
         'other': OtherFields(),

--- a/tinytag/tinytag.py
+++ b/tinytag/tinytag.py
@@ -1813,12 +1813,7 @@ class _Ogg(TinyTag):
             elif check_speex_second_packet:
                 if self._parse_tags:
                     walker = BytesIO(packet)
-                    # starts with a comment string
-                    length = unpack('I', walker.read(4))[0]
-                    comment = walker.read(length).decode('utf-8', 'replace')
-                    self._set_field('comment', comment)
-                    # other tags
-                    self._set_vorbis_comment_fields(walker, has_vendor=False)
+                    self._set_vorbis_comment_fields(walker)
                     self._tags_parsed = True
                 check_speex_second_packet = False
             if self._tags_parsed and not self._parse_duration:
@@ -1838,16 +1833,14 @@ class _Ogg(TinyTag):
     def _parse_vorbis_comment(
         cls,
         fh: BinaryIO,
-        has_vendor: bool = True,
         load_image: bool = False,
         read_data: bool = True
     ) -> Iterator[tuple[str, str | int | Image]]:
         # for the spec, see: http://xiph.org/vorbis/doc/v-comment.html
         # discnumber tag based on: https://en.wikipedia.org/wiki/Vorbis_comment
         # https://sno.phy.queensu.ca/~phil/exiftool/TagNames/Vorbis.html
-        if has_vendor:
-            vendor_length = unpack('I', fh.read(4))[0]
-            fh.seek(vendor_length, SEEK_CUR)  # jump over vendor
+        vendor_length = unpack('I', fh.read(4))[0]
+        fh.seek(vendor_length, SEEK_CUR)  # jump over vendor
         elements = unpack('I', fh.read(4))[0]
         for _i in range(elements):
             length = unpack('I', fh.read(4))[0]
@@ -1884,11 +1877,9 @@ class _Ogg(TinyTag):
                     else:
                         yield fieldname, value
 
-    def _set_vorbis_comment_fields(self,
-                                   fh: BinaryIO,
-                                   has_vendor: bool = True) -> None:
+    def _set_vorbis_comment_fields(self, fh: BinaryIO) -> None:
         for fieldname, value in self._parse_vorbis_comment(
-            fh, has_vendor, self._load_image
+            fh, self._load_image
         ):
             if isinstance(value, Image):
                 self.images._set_field(fieldname, value)


### PR DESCRIPTION
I think I must've misinterpreted the spec when I originally implemented this. There's no special behavior here.